### PR TITLE
338: Add environment banner to public site header

### DIFF
--- a/src/app/header/header.component.html
+++ b/src/app/header/header.component.html
@@ -24,3 +24,6 @@
         </div>
     </div>
 </nav>
+<div *ngIf="showBanner" class="env-banner text-center bg-danger text-white py-2">
+    This is the <strong>{{ envName }}</strong> environment. The content you are viewing is not final and subject to change.
+</div>

--- a/src/app/header/header.component.ts
+++ b/src/app/header/header.component.ts
@@ -2,6 +2,7 @@ import { CommonModule } from '@angular/common';
 import { Component} from '@angular/core';
 import { AuthService } from '../services/auth.service';
 import { RouterModule, Router } from '@angular/router';
+import { ConfigService } from '../services/config.service';
 
 @Component({
     selector: 'app-header',
@@ -10,8 +11,16 @@ import { RouterModule, Router } from '@angular/router';
     styleUrl: './header.component.scss'
 })
 export class HeaderComponent { 
+  public envName: string;
+  public showBanner = true;
 
-  constructor(private authService: AuthService, private router: Router) {}
+  constructor(private authService: AuthService, private router: Router, private configService: ConfigService) {
+    this.envName = this.configService.config['ENVIRONMENT'] || 'local';
+    // Hide banner in production
+    if (this.envName === 'prod') {
+      this.showBanner = false;
+    }
+  }
 
   get user() {
     return this.authService.getCurrentUser(); // Directly bind to the signal


### PR DESCRIPTION
Display environment banner on dev/test/local environments to alert users they are viewing non-production content. Banner is hidden in production. Matches existing implementation pattern from reserve-rec-admin.