### PR TITLE
#176: Add payment retry UI for failed payments

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -18,6 +18,7 @@ export const routes: Routes = [
   { path: 'find-booking', loadComponent: () => import('./find-booking/find-booking.component').then(mod => mod.FindBookingComponent) },
   { path: 'login', loadComponent: () => import('./login/login.component').then(mod => mod.LoginComponent) },
   { path: 'my-bookings', loadComponent: () => import('./my-bookings/my-bookings.component').then(mod => mod.MyBookingsComponent), canActivate: [UserGuard], resolve: { user: UserResolver } },
+  { path: 'payment-retry', loadComponent: () => import('./payment-retry/payment-retry.component').then(mod => mod.PaymentRetryComponent) },
   { path: 'protected-area/:orcs', loadComponent: () => import('./protected-area-details/protected-area-details.component').then(mod => mod.ProtectedAreaDetailsComponent) },
   { path: 'reservation-flow', loadComponent: () => import('./reservation-flow/reservation-flow.component').then(mod => mod.ReservationFlowComponent), canActivate: [CheckoutGuard] },
   { path: 'results', loadComponent: () => import('./search-results/search-results.component').then(mod => mod.SearchResultsComponent) },

--- a/src/app/payment-retry/payment-retry.component.html
+++ b/src/app/payment-retry/payment-retry.component.html
@@ -1,0 +1,101 @@
+<div class="container mt-5">
+  <div class="row justify-content-center">
+    <div class="col-md-8 col-lg-6">
+      <div class="card shadow">
+        <div class="card-body">
+          <h2 class="card-title text-danger">
+            <i class="bi bi-exclamation-triangle-fill me-2"></i>
+            Payment Failed
+          </h2>
+
+          @if (bookingError()) {
+            <div class="alert alert-danger" role="alert">
+              <strong>Error:</strong> {{ bookingError() }}
+            </div>
+            <div class="d-grid gap-2">
+              <button class="btn btn-primary" (click)="goHome()">
+                Return to Home
+              </button>
+            </div>
+          } @else {
+            <div class="alert alert-warning" role="alert">
+              {{ errorMessage() }}
+            </div>
+
+            @if (booking()) {
+              <div class="mb-4">
+                <h5>Booking Details</h5>
+                <dl class="row">
+                  <dt class="col-sm-4">Activity:</dt>
+                  <dd class="col-sm-8">{{ booking().displayName }}</dd>
+
+                  <dt class="col-sm-4">Check-in:</dt>
+                  <dd class="col-sm-8">{{ booking().startDate | date:'mediumDate' }}</dd>
+
+                  <dt class="col-sm-4">Check-out:</dt>
+                  <dd class="col-sm-8">{{ booking().endDate | date:'mediumDate' }}</dd>
+
+                  @if (booking().feeInformation) {
+                    <dt class="col-sm-4">Total Amount:</dt>
+                    <dd class="col-sm-8">
+                      <strong>${{ booking().feeInformation.total | number:'1.2-2' }}</strong>
+                    </dd>
+                  }
+
+                  @if (booking().sessionExpiry) {
+                    <dt class="col-sm-4">Session Expires:</dt>
+                    <dd class="col-sm-8 text-danger">
+                      {{ booking().sessionExpiry | date:'short' }}
+                    </dd>
+                  }
+                </dl>
+              </div>
+
+              <div class="d-grid gap-2">
+                <button 
+                  class="btn btn-primary btn-lg" 
+                  (click)="retryPayment()"
+                  [disabled]="isProcessing()">
+                  @if (isProcessing()) {
+                    <span class="spinner-border spinner-border-sm me-2" role="status"></span>
+                    Processing...
+                  } @else {
+                    <i class="bi bi-credit-card me-2"></i>
+                    Retry Payment
+                  }
+                </button>
+
+                <button 
+                  class="btn btn-outline-secondary" 
+                  (click)="goHome()"
+                  [disabled]="isProcessing()">
+                  Return to Home
+                </button>
+
+                <button 
+                  class="btn btn-outline-danger" 
+                  (click)="cancelBooking()"
+                  [disabled]="isProcessing()">
+                  Cancel Booking
+                </button>
+              </div>
+            } @else {
+              <div class="text-center py-4">
+                <div class="spinner-border text-primary" role="status">
+                  <span class="visually-hidden">Loading...</span>
+                </div>
+                <p class="mt-2">Loading booking details...</p>
+              </div>
+            }
+          }
+        </div>
+      </div>
+
+      <div class="mt-3 text-center">
+        <small class="text-muted">
+          Need help? <a href="mailto:support@bcparks.ca">Contact Support</a>
+        </small>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/payment-retry/payment-retry.component.scss
+++ b/src/app/payment-retry/payment-retry.component.scss
@@ -1,0 +1,36 @@
+.card {
+  border-radius: 12px;
+
+  .card-title {
+    margin-bottom: 1.5rem;
+    font-size: 1.75rem;
+  }
+
+  .alert {
+    margin-bottom: 1.5rem;
+  }
+
+  dl {
+    margin-bottom: 0;
+
+    dt {
+      font-weight: 600;
+      color: #6c757d;
+    }
+
+    dd {
+      margin-bottom: 0.5rem;
+    }
+  }
+
+  .btn {
+    font-weight: 500;
+    padding: 0.75rem 1.5rem;
+  }
+}
+
+.spinner-border-sm {
+  width: 1rem;
+  height: 1rem;
+  border-width: 0.15em;
+}

--- a/src/app/payment-retry/payment-retry.component.ts
+++ b/src/app/payment-retry/payment-retry.component.ts
@@ -1,0 +1,142 @@
+import { Component, OnInit, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
+import { BookingService } from '../services/booking.service';
+import { ApiService } from '../services/api.service';
+import { lastValueFrom } from 'rxjs';
+
+@Component({
+  selector: 'app-payment-retry',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './payment-retry.component.html',
+  styleUrl: './payment-retry.component.scss'
+})
+export class PaymentRetryComponent implements OnInit {
+  bookingId = signal<string>('');
+  sessionId = signal<string>('');
+  email = signal<string>('');
+  errorMessage = signal<string>('');
+  isProcessing = signal<boolean>(false);
+  booking = signal<any>(null);
+  bookingError = signal<string>('');
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private bookingService: BookingService,
+    private apiService: ApiService
+  ) {}
+
+  ngOnInit() {
+    this.route.queryParams.subscribe(params => {
+      this.bookingId.set(params['bookingId'] || '');
+      this.sessionId.set(params['sessionId'] || '');
+      this.email.set(params['email'] || '');
+      this.errorMessage.set(params['error'] || 'Payment was not completed');
+      
+      if (this.bookingId()) {
+        this.loadBooking();
+      } else {
+        this.bookingError.set('No booking ID provided');
+      }
+    });
+  }
+
+  async loadBooking() {
+    try {
+      const response: any = await lastValueFrom(
+        this.apiService.get(`bookings/${this.bookingId()}`, {})
+      );
+      this.booking.set(response?.data);
+      
+      // Check if booking is still valid
+      if (response?.data?.bookingStatus === 'confirmed') {
+        this.bookingError.set('This booking has already been paid.');
+      } else if (response?.data?.bookingStatus === 'cancelled') {
+        this.bookingError.set('This booking has been cancelled.');
+      } else if (response?.data?.sessionExpiry) {
+        const expiryTime = new Date(response.data.sessionExpiry).getTime();
+        const now = Date.now();
+        if (now > expiryTime) {
+          this.bookingError.set('Your booking session has expired. Please create a new booking.');
+        }
+      }
+    } catch (error: any) {
+      console.error('Error loading booking:', error);
+      if (error?.status === 404) {
+        this.bookingError.set('Booking not found.');
+      } else {
+        this.bookingError.set('Unable to load booking details. Please try again.');
+      }
+    }
+  }
+
+  async retryPayment() {
+    if (!this.bookingId() || !this.sessionId() || this.isProcessing() || this.bookingError()) {
+      return;
+    }
+    
+    this.isProcessing.set(true);
+    
+    try {
+      const body = {
+        trnAmount: this.booking()?.feeInformation?.total || 0,
+        bookingId: this.bookingId(),
+        sessionId: this.sessionId(),
+        email: this.email()
+      };
+      
+      const response: any = await lastValueFrom(
+        this.apiService.post('transactions', body, {})
+      );
+      const transactionUrl = response?.data?.response?.transaction?.data?.transactionUrl;
+      
+      if (transactionUrl) {
+        // Redirect to Worldline payment page
+        window.location.href = transactionUrl;
+      } else {
+        throw new Error('No transaction URL returned');
+      }
+    } catch (error: any) {
+      console.error('Error retrying payment:', error);
+      
+      if (error?.error?.message?.includes('expired')) {
+        this.bookingError.set('Your booking session has expired. Please create a new booking.');
+      } else if (error?.error?.message?.includes('Unauthorized')) {
+        this.bookingError.set('You do not have permission to pay for this booking.');
+      } else {
+        alert('Failed to retry payment. Please try again or contact support.');
+      }
+      this.isProcessing.set(false);
+    }
+  }
+
+  async cancelBooking() {
+    if (!this.bookingId() || this.isProcessing()) {
+      return;
+    }
+    
+    if (!confirm('Are you sure you want to cancel this booking?')) {
+      return;
+    }
+    
+    this.isProcessing.set(true);
+    
+    try {
+      await lastValueFrom(
+        this.bookingService.cancelBooking(this.bookingId())
+      );
+      alert('Booking cancelled successfully.');
+      this.router.navigate(['/']);
+    } catch (error) {
+      console.error('Error cancelling booking:', error);
+      alert('Failed to cancel booking. Please contact support.');
+      this.isProcessing.set(false);
+    }
+  }
+
+  goHome() {
+    this.router.navigate(['/']);
+  }
+}

--- a/src/app/services/booking.service.ts
+++ b/src/app/services/booking.service.ts
@@ -91,4 +91,8 @@ export class BookingService {
       throw error; // Re-throw the error for further handling if needed
     }
   }
+
+  cancelBooking(bookingId: string) {
+    return this.apiService.delete(`bookings/${bookingId}`, {});
+  }
 }

--- a/src/app/transaction-status/transaction-status.component.ts
+++ b/src/app/transaction-status/transaction-status.component.ts
@@ -45,9 +45,27 @@ export class TransactionStatusComponent {
           queryParams: queryParams 
         });
       } else {
-        // TODO: if fails, redirect to checkout with sessionIds
-        console.log('Redirecting to home...');
-        this.router.navigate(['/']);
+        // Payment failed - redirect to payment retry page with booking info
+        const bookingId = response?.ref1 || this.route.snapshot.queryParams['ref1'];
+        const sessionId = response?.ref2 || this.route.snapshot.queryParams['ref2'];
+        const email = response?.ref3 || this.route.snapshot.queryParams['ref3'];
+        const errorMsg = response?.messageText || 'Payment was not completed';
+        
+        console.log('Payment failed, redirecting to payment-retry page...');
+        
+        // Preserve booking info for retry (don't clear cart yet)
+        if (bookingId) {
+          sessionStorage.setItem('failedBookingId', bookingId);
+        }
+        
+        this.router.navigate(['/payment-retry'], {
+          queryParams: {
+            bookingId: bookingId,
+            sessionId: sessionId,
+            email: email,
+            error: errorMsg
+          }
+        });
       }
     }
   });


### PR DESCRIPTION
## Summary
Adds `/payment-retry` component allowing users to retry failed payments within a 30-minute window.

## Key Changes
- New payment retry page with booking details, session expiry, and retry/cancel buttons
- Failed payments redirect to retry UI automatically
- Error handling for expired sessions and unauthorized access
- Added `cancelBooking()` to booking service

## Notes
- Missing unit tests for `payment-retry.component.spec.ts` (follow-up)

## Related
- Issue: bcgov/reserve-rec-api#176
- Backend PR: bcgov/reserve-rec-api#TBD