### PR TITLE
NOBUG - adding distribution id and domain name export

### DIFF
--- a/lib/distribution-stack/distribution-stack.js
+++ b/lib/distribution-stack/distribution-stack.js
@@ -208,6 +208,12 @@ class DistributionStack extends BaseStack {
       logBucket: this.logBucket,
       logIncludesCookies: false,
     });
+
+    // Export References
+
+    this.exportReference(this, 'distributionId', this.publicDistribution.distributionId, `ID of the Public CloudFront Distribution in ${this.stackId}`);
+
+    this.exportReference(this, 'distributionDomainName', this.publicDistribution.domainName, `Domain Name of the Public CloudFront Distribution in ${this.stackId}`);
   }
 }
 


### PR DESCRIPTION
Public FE does not currently export domain ID or name to Parameter Store - they are needed as an import in some cases.