### PR TITLE
feat: Add feature flags support to public app (#113)

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -6,14 +6,16 @@ import { ConfigService } from './services/config.service';
 import { provideHttpClient } from '@angular/common/http';
 import { ApiService } from './services/api.service';
 import { AuthService } from './services/auth.service';
+import { FeatureFlagService } from './services/feature-flag.service';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideToastr } from 'ngx-toastr';
 
-export function initConfig(configService: ConfigService, apiService: ApiService, authService: AuthService) {
+export function initConfig(configService: ConfigService, apiService: ApiService, authService: AuthService, featureFlagService: FeatureFlagService) {
   return async () => {
     await configService.init();
     await authService.init();
     apiService.init();
+    await featureFlagService.init();
   };
 }
 
@@ -23,7 +25,7 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideAppInitializer(() => {
-      const initializerFn = (initConfig)(inject(ConfigService), inject(ApiService), inject(AuthService));
+      const initializerFn = (initConfig)(inject(ConfigService), inject(ApiService), inject(AuthService), inject(FeatureFlagService));
       return initializerFn();
     }),
     provideAnimations(),

--- a/src/app/services/feature-flag.service.ts
+++ b/src/app/services/feature-flag.service.ts
@@ -1,0 +1,50 @@
+import { Injectable, signal } from '@angular/core';
+import { lastValueFrom } from 'rxjs';
+import { ApiService } from './api.service';
+import { LoggerService } from './logger.service';
+
+@Injectable({ providedIn: 'root' })
+export class FeatureFlagService {
+  private _flags = signal<Record<string, boolean>>({});
+  private _initialized = signal<boolean>(false);
+  
+  // Public readonly signals
+  public flags = this._flags.asReadonly();
+  public initialized = this._initialized.asReadonly();
+
+  // Default flags (used as fallback)
+  private readonly defaultFlags: Record<string, boolean> = {
+    enablePayments: true
+  };
+
+  constructor(
+    private apiService: ApiService,
+    private loggerService: LoggerService
+  ) {}
+
+  /**
+   * Initialize feature flags - called during app bootstrap
+   * Fetches from public GET /featureFlags endpoint (no auth required)
+   */
+  async init(): Promise<void> {
+    try {
+      this.loggerService.debug('Initializing feature flags...');
+      const response = await lastValueFrom(this.apiService.get('featureFlags'));
+      this._flags.set(response || this.defaultFlags);
+      this._initialized.set(true);
+      this.loggerService.debug('Feature flags initialized:', this._flags());
+    } catch (error) {
+      this.loggerService.error('Failed to load feature flags, using defaults:', error);
+      this._flags.set(this.defaultFlags);
+      this._initialized.set(true);
+    }
+  }
+
+  /**
+   * Check if a feature flag is enabled
+   */
+  isEnabled(flagKey: string): boolean {
+    const flags = this._flags();
+    return flags[flagKey] ?? this.defaultFlags[flagKey] ?? false;
+  }
+}


### PR DESCRIPTION
- Create read-only FeatureFlagService
- Add service to app bootstrap initialization
- Fetch flags from public API endpoint on app load
- Provide isEnabled() method for conditional feature display
- Graceful fallback to defaults on error
- No admin UI (public users cannot manage flags)
- Initial flag: enablePayments (default: true)

Implements public frontend portion of #113