### PR TITLE
fix: extract data from API response in FeatureFlagService (#113)

### DIFF
--- a/src/app/services/feature-flag.service.ts
+++ b/src/app/services/feature-flag.service.ts
@@ -29,8 +29,8 @@ export class FeatureFlagService {
   async init(): Promise<void> {
     try {
       this.loggerService.debug('Initializing feature flags...');
-      const response = await lastValueFrom(this.apiService.get('featureFlags'));
-      this._flags.set((response as Record<string, boolean>) || this.defaultFlags);
+      const response: any = await lastValueFrom(this.apiService.get('featureFlags'));
+      this._flags.set(response?.data || this.defaultFlags);
       this._initialized.set(true);
       this.loggerService.debug(`Feature flags initialized: ${JSON.stringify(this._flags())}`);
     } catch (error) {


### PR DESCRIPTION
The public FeatureFlagService was setting _flags to the entire API response object instead of extracting response.data. This caused isEnabled() to always fall back to defaults since the flags object structure was incorrect.

API returns: { code: 200, data: { enablePayments: true }, msg: 'Success', ... }
Service needs: { enablePayments: true }

This fix mirrors the same pattern used in the admin FeatureFlagService.