### PR TITLE
fix: redirect to home when accessing /login while already authenticat…

### DIFF
--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { AmplifyAuthenticatorModule } from '@aws-amplify/ui-angular';
 import { AuthService } from '../services/auth.service';
 import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
 
 
 @Component({
@@ -12,9 +13,18 @@ import { CommonModule } from '@angular/common';
 })
 
 export class LoginComponent implements OnInit{
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private router: Router
+  ) {}
   currentDate = '';
   ngOnInit() {
+    // If user is already authenticated, redirect to home
+    if (this.authService.user()) {
+      this.router.navigate(['/']);
+      return;
+    }
+
     const now = new Date();
     const options: Intl.DateTimeFormatOptions = { month: 'short', day: '2-digit', year: 'numeric' };
     this.currentDate = new Intl.DateTimeFormat('en-US', options).format(now).replace(',', '').replace(' ', '-');


### PR DESCRIPTION
…ed (#364)

When a user navigates to /login (via back button or direct URL) while already logged in, the page was showing a 'Sign Out' button instead of redirecting to the home page.

This change adds a check in ngOnInit() to redirect authenticated users to the home page, providing a better user experience and preventing confusion.