### PR TITLE
fix: remove guest checkout support from frontend (#251)

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -23,5 +23,5 @@ export const routes: Routes = [
   { path: 'reservation-flow', loadComponent: () => import('./reservation-flow/reservation-flow.component').then(mod => mod.ReservationFlowComponent), canActivate: [CheckoutGuard] },
   { path: 'results', loadComponent: () => import('./search-results/search-results.component').then(mod => mod.SearchResultsComponent) },
   { path: 'search', loadComponent: () => import('./search-page/search-page.component').then(mod => mod.SearchPageComponent) },
-  { path: 'transaction-status', loadComponent: () => import('./transaction-status/transaction-status.component').then(mod => mod.TransactionStatusComponent)},
+  { path: 'transaction-status', loadComponent: () => import('./transaction-status/transaction-status.component').then(mod => mod.TransactionStatusComponent), canActivate: [UserGuard]},
 ];

--- a/src/app/guards/user.guard.ts
+++ b/src/app/guards/user.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, Router } from '@angular/router';
+import { CanActivate, Router, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
 import { AuthService } from '../services/auth.service';
 
 @Injectable({
@@ -8,12 +8,14 @@ import { AuthService } from '../services/auth.service';
 export class UserGuard implements CanActivate {
     constructor(private authService: AuthService, private router: Router) {}
   
-    async canActivate(): Promise<boolean> {
+    async canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Promise<boolean> {
       const user = await this.authService.getCurrentUser();
       if (user) {
         return true; // Allow access if user exists
       } else {
-        this.router.navigate(['/login']); // No user exists, redirect to login
+        // Store the return URL in sessionStorage for post-login redirect
+        sessionStorage.setItem('returnUrl', state.url);
+        this.router.navigate(['/login']);
         return false;
       }
     }

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { AmplifyAuthenticatorModule } from '@aws-amplify/ui-angular';
 import { AuthService } from '../services/auth.service';
 import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
 
 
 @Component({
@@ -12,9 +13,18 @@ import { CommonModule } from '@angular/common';
 })
 
 export class LoginComponent implements OnInit{
-  constructor(private authService: AuthService) {}
+  constructor(
+    private authService: AuthService,
+    private router: Router
+  ) {}
   currentDate = '';
   ngOnInit() {
+    // If user is already authenticated, redirect to home
+    if (this.authService.user()) {
+      this.router.navigate(['/']);
+      return;
+    }
+
     const now = new Date();
     const options: Intl.DateTimeFormatOptions = { month: 'short', day: '2-digit', year: 'numeric' };
     this.currentDate = new Intl.DateTimeFormat('en-US', options).format(now).replace(',', '').replace(' ', '-');

--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -67,14 +67,6 @@ export class ApiService implements OnDestroy {
     if (this.token) {
       this.headers = this.headers.set('Authorization', `Bearer ${this.token}`);
       console.log('Using JWT token auth');
-    } else {
-      // Check if we have a stored guest sub
-      const guestSub = this.authService.getGuestSub();
-      if (guestSub) {
-        this.headers = this.headers.set('Authorization', `Guest ${guestSub}`);
-      } else {
-        this.headers = this.headers.set('Authorization', 'guest');
-      }
     }
   }
 
@@ -102,14 +94,7 @@ export class ApiService implements OnDestroy {
       this.updateHeaders();
       return this.http.get(`${this.apiPath}/${pk}?${queryString}`, { headers: this.headers, observe: 'response' })
         .pipe(
-          map(response => {
-            // Capture guest sub from response headers if present
-            const guestSub = response?.headers?.get('x-guest-sub');
-            if (guestSub) {
-              this.authService.setGuestSub(guestSub);
-            }
-            return response?.body;
-          }),
+          map(response => response?.body),
           catchError(this.errorHandler)
         );
     } else {
@@ -139,14 +124,7 @@ export class ApiService implements OnDestroy {
       return this.http
         .post<any>(`${this.apiPath}/${pk}?${queryString}`, obj, { headers: this.headers, observe: 'response' })
         .pipe(
-          map(response => {
-            // Capture guest sub from response headers if present
-            const guestSub = response?.headers?.get('x-guest-sub');
-            if (guestSub) {
-              this.authService.setGuestSub(guestSub);
-            }
-            return response?.body;
-          }),
+          map(response => response?.body),
           catchError(this.errorHandler)
         );
     } else {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -13,7 +13,6 @@ export class AuthService {
   public user = signal<any>(null); // Observable for user updates
   public session = signal(null);
   public redirectValues;
-  private readonly GUEST_SUB_KEY = 'guest_sub';
   jwtToken: any;
 
   constructor(private configService: ConfigService, private loggerService: LoggerService, private router: Router) { }
@@ -110,7 +109,15 @@ export class AuthService {
           const session = await fetchAuthSession();
           this.jwtToken = session.credentials.sessionToken;
           await this.setRefresh();
-          this.router.navigate(['/']);
+          
+          // Check for returnUrl in sessionStorage (set by guard)
+          const returnUrl = sessionStorage.getItem('returnUrl');
+          if (returnUrl) {
+            sessionStorage.removeItem('returnUrl');
+            this.router.navigateByUrl(returnUrl);
+          } else {
+            this.router.navigate(['/']);
+          }
           break;
         }
         case 'signedOut': {
@@ -186,7 +193,6 @@ export class AuthService {
     await signOut();
     this.updateUser(null);
     this.session.set(null);
-    this.clearGuestSub(); // Clear guest session on logout
     console.log('User logged out', this.user);
     this.router.navigate(['/']);
   }
@@ -198,29 +204,7 @@ export class AuthService {
   //Just use to confirm is user is logged
   getCurrentUser() {
     try {
-      if (this.user()) {
-        return this.user() || '';
-      } else {
-        // Check for guest session
-        const guestSub = this.getGuestSub();
-        return {
-            "email": "null",
-            "email_verified": "false",
-            "family_name": "guest",
-            "given_name": "guest",
-            "custom:secondaryNumber": "",
-            "custom:country": "",
-            "custom:licensePlate": "",
-            "custom:vehicleRegLocale": "",
-            "custom:pwUpdate": "",
-            "custom:streetAddress": "",
-            "custom:mobilePhone": "",
-            "custom:province": "",
-            "custom:city": "",
-            "custom:postalCode": "",
-            "sub": guestSub || "guest"
-        }
-      }
+      return this.user() || null;
     } catch (error) {
       this.loggerService.error(`Error fetching current user: ${error}`);
       return null;
@@ -234,35 +218,10 @@ export class AuthService {
       this.jwtToken = this.session()?.credentials?.sessionToken;
     } catch (error) {
       console.log('User is not signed in:', error);
-      // Don't logout - preserve guest session if it exists
-      // Only clear authenticated user state
+      // Clear authenticated user state
       this.updateUser(null);
       this.session.set(null);
     }
-  }
-
-  /**
-   * Store guest sub in sessionStorage for the current session
-   */
-  setGuestSub(guestSub: string) {
-    if (guestSub && guestSub.startsWith('guest-')) {
-      sessionStorage.setItem(this.GUEST_SUB_KEY, guestSub);
-      this.loggerService.info(`Guest session established: ${guestSub}`);
-    }
-  }
-
-  /**
-   * Retrieve guest sub from sessionStorage
-   */
-  getGuestSub(): string | null {
-    return sessionStorage.getItem(this.GUEST_SUB_KEY);
-  }
-
-  /**
-   * Clear guest session
-   */
-  clearGuestSub() {
-    sessionStorage.removeItem(this.GUEST_SUB_KEY);
   }
 
   //Setup to match logic for admin. Gives opprotunity to add BCEID in future.

--- a/src/app/transaction-status/transaction-status.component.ts
+++ b/src/app/transaction-status/transaction-status.component.ts
@@ -27,8 +27,7 @@ export class TransactionStatusComponent {
   ) {
     const params = this.route.snapshot.queryParams;
     const clientTransactionId = params['trnOrderNumber'];
-    const sessionId = params['ref2'];
-    this.queryTransaction(clientTransactionId, sessionId);
+    this.queryTransaction(clientTransactionId);
   }
 
   transactionEffect = effect(() => {
@@ -70,12 +69,11 @@ export class TransactionStatusComponent {
     }
   });
 
-  async queryTransaction(clientTransactionId: string, sessionId: string) {
+  async queryTransaction(clientTransactionId: string) {
     try {
       this.loadingService.addToFetchList(Constants.dataIds.TRANSACTION_STATUS_RESULTS);
       const queryParams = {
-        clientTransactionId,
-        sessionId
+        clientTransactionId
       };
       const res: any = await lastValueFrom(
         this.apiService.get(`transactions`, queryParams)


### PR DESCRIPTION
## Summary

Removes guest session handling and requires authentication for transaction status viewing in the reserve-rec-public frontend. This PR implements the frontend portion of issue #251.

### Changes Made

- **API Service** (`src/app/services/api.service.ts`):
  - Removed guest authorization fallback (`Guest` and `guest` auth headers)
  - Removed `x-guest-sub` header capture from GET and POST responses
  - Now only uses JWT Bearer tokens for authenticated requests

- **Auth Service** (`src/app/services/auth.service.ts`):
  - Removed `GUEST_SUB_KEY` constant
  - Removed `setGuestSub()`, `getGuestSub()`, `clearGuestSub()` methods
  - Updated `getCurrentUser()` to return `null` instead of guest user object
  - Added returnUrl support in sign-in handler for post-login redirect

- **Transaction Status Component** (`src/app/transaction-status/transaction-status.component.ts`):
  - Removed `sessionId` from query params in constructor
  - Removed `sessionId` parameter from `queryTransaction()` method
  - Now relies on JWT authentication for transaction lookup

- **User Guard** (`src/app/guards/user.guard.ts`):
  - Added `ActivatedRouteSnapshot` and `RouterStateSnapshot` parameters
  - Now stores returnUrl in sessionStorage before redirecting to login
  - Enables seamless redirect back to protected page after authentication

- **Routes** (`src/app/app.routes.ts`):
  - Added `UserGuard` to `/transaction-status` route
  - Unauthenticated users now redirected to login

- **Login Component** (`src/app/login/login.component.ts`):
  - Added early return if user already authenticated

### Important Notes

- **sessionId is still used** for payment flow (Transaction POST, Worldline redirect) - only removed from Transaction GET authorization
- **Works with backend PR** in reserve-rec-api that enforces authentication at booking creation
- **Seamless login flow** - users attempting to view transactions are redirected to login, then back to transaction-status

### Acceptance Criteria

- [x] Given I'm not logged in
- [x] When I attempt to view transaction status
- [x] Then I'm redirected to login
- [x] After successful login, I'm redirected back to transaction-status
- [x] Authenticated users can view transactions normally

### Related PRs

- Backend PR: bcgov/reserve-rec-api#284

Fixes #251