### PR TITLE
feat(waiting-room): enforce Mode 2 gate on facility and cart routes

### DIFF
--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -13,6 +13,13 @@ permissions:
   id-token: write
   contents: read
 
+concurrency:
+  group: deploy-reserve-rec-public-prod
+  cancel-in-progress: false
+
+env:
+  S3_BUCKET: ${{ vars.S3_BUCKET }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -22,15 +29,43 @@ jobs:
       matrix:
         node-version: [20.x]
     steps:
+      ### Restore cdk.out cache
+      - name: Restore cdk.out cache
+        uses: actions/cache@v4
+        with:
+          path: cdk.out
+          # A static cache key is fine since cdk deploy will overwrite files as needed
+          key: ${{ runner.os }}-prod-cdk-out
+          restore-keys: |
+            ${{ runner.os }}-prod-cdk-out
+
       ### Checkout GitHub Repo
       - name: Checkout repo
         uses: actions/checkout@v4
 
-      # - shell: bash
-      #   env:
-      #     WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
-      #   run: |
-      #     curl -X POST -H 'Content-Type: application/json' $WEBHOOK_URL --data '{"text":"Reserve Rec - Deploy Public Prod"}'
+      - name: Install AWS CDK
+        run: |
+          yarn
+          yarn global add aws-cdk
+
+      ### Assume AWS IAM Role
+      - name: Get AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: GitHub_to_AWS_via_FederatedOIDC
+          aws-region: ${{ vars.AWS_REGION }}
+
+      ### CDK Deploy
+      - name: CDK Deploy
+        run: export LOG_LEVEL=debug && cdk deploy -c @context=prod --all --require-approval never --rollback
+
+      ### Save cdk.out cache
+      - name: Save cdk.out cache
+        uses: actions/cache@v4
+        with:
+          path: cdk.out
+          key: ${{ runner.os }}-prod-cdk-out
 
       ### Install if no cache exists ###
       - name: Setup node
@@ -38,9 +73,10 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
           cache: "yarn"
+          cache-dependency-path: "yarn.lock"
       - run: yarn install --silent --frozen-lockfile
 
-      ### Build if no cache exists ###
+      ### Build ###
       - name: Cache Build
         id: cache-build
         uses: actions/cache@v4
@@ -56,74 +92,20 @@ jobs:
           sed 's@localConfigEndpoint@'true'@g' src/env.js.template | sed 's@localGHHash@'"$GH_HASH"'@g' > src/env.js
           yarn build
 
-      ### Setup AWS SAM
-      - name: Setup AWS SAM
-        uses: aws-actions/setup-sam@v2
-        with:
-          use-installer: true
-
-      ### Assume AWS IAM Role
-      - name: Get AWS credentials
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
-          role-session-name: GitHub_to_AWS_via_FederatedOIDC
-          aws-region: ${{ vars.AWS_REGION }}
-
-      ### SAM Build
-      - name: Cache SAM Build
-        id: cache-sam-build
-        uses: actions/cache@v4
-        with:
-          path: |
-            **.aws-sam
-          key: ${{ github.sha }}-sam-cache
-      - name: Run sam build
-        if: steps.cache-sam-build.outputs.cache-hit != 'true'
-        run: |
-          sam build --cached
-
-      ### Prevent prompts and failure when the stack is unchanged
-      - name: SAM deploy
-        env:
-          STACK_NAME: ${{ vars.STACK_NAME }}
-          DIST_ORIGIN_PATH: "latest"
-          API_GATEWAY_ID: ${{ vars.API_GATEWAY_ID }}
-          ENV: ${{ vars.ENVIRONMENT_STAGE }}
-          AWS_REGION: ${{ vars.AWS_REGION }}
-          API_STAGE: ${{ vars.API_STAGE }}
-          DOMAIN_NAME: ${{ vars.DOMAIN_NAME }}
-          AWS_CERTIFICATE_ARN: ${{ vars.AWS_CERTIFICATE_ARN }}
-          API_CACHE_POLICY_ID: ${{ vars.API_CACHE_POLICY_ID }}
-        run: |
-          sam deploy --stack-name $STACK_NAME --no-confirm-changeset --no-fail-on-empty-changeset --parameter-overrides \
-          DistOriginPath=$DIST_ORIGIN_PATH \
-          ApiGatewayId=$API_GATEWAY_ID \
-          Env=$ENV \
-          AWSRegion=$AWS_REGION \
-          ApiStage=$API_STAGE \
-          EnvDomainName=$DOMAIN_NAME \
-          DomainCertificateArn=$AWS_CERTIFICATE_ARN \
-          ApiCachePolicyId=$API_CACHE_POLICY_ID \
-
       ### Upload dist to S3 ###
       - name: Deploy to S3
         env:
-          S3_BUCKET_PUBLIC: ${{ vars.STACK_NAME }}-${{ vars.ENVIRONMENT_STAGE }}
           DIR_NAME: ${{ github.sha }}
         run: |
-          aws s3 sync dist s3://$S3_BUCKET_PUBLIC/$DIR_NAME
-          aws s3 rm s3://$S3_BUCKET_PUBLIC/ --recursive --exclude "*" --include "latest/*"
-          aws s3 sync dist s3://$S3_BUCKET_PUBLIC/latest
+          echo "Deploying to $S3_BUCKET/$DIR_NAME"
+          aws s3 sync dist s3://$S3_BUCKET/$DIR_NAME
+          aws s3 rm s3://$S3_BUCKET/ --recursive --exclude "*" --include "latest/*"
+          aws s3 sync dist s3://$S3_BUCKET/latest
 
-      - name: Invalidate CloudFront
-        uses: chetan/invalidate-cloudfront-action@v2
+      ### Invalidate CloudFront Cache ###
+      - name: Invalidate CloudFront Cache
         env:
-          DISTRIBUTION: ${{ secrets.DISTRIBUTION }}
-          PATHS: "/*"
-
-      # - shell: bash
-      #   env:
-      #     WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
-      #   run: |
-      #     curl -X POST -H 'Content-Type: application/json' $WEBHOOK_URL --data '{"text":"Reserve Rec - Deploy Public Prod Complete"}'
+          DISTRIBUTION_ID: ${{ vars.CLOUDFRONT_DISTRIBUTION_ID }}
+        run: |
+          echo "Invalidating CloudFront Distribution ID: $DISTRIBUTION_ID"
+          aws cloudfront create-invalidation --distribution-id $DISTRIBUTION_ID --paths "/*"

--- a/bin/app.js
+++ b/bin/app.js
@@ -183,12 +183,16 @@ class CDKProject {
     // Edge stack (us-east-1): WAF WebACL for CloudFront.
     // Must be created before distributionStack so the WAF ARN is in ca-central-1 SSM when
     // the distribution stack resolves it at deploy time.
-    const edgeStack = await this.addStack('waitingRoomEdgeStack', createWaitingRoomEdgeStack);
+    // Skipped when DEPLOY_EDGE_STACK=false (e.g. prod — us-east-1 CloudFormation blocked by SCP).
+    let edgeStack = null;
+    if (this.context?.DEPLOY_EDGE_STACK !== 'false') {
+      edgeStack = await this.addStack('waitingRoomEdgeStack', createWaitingRoomEdgeStack);
 
-    // Bind edge stack reference on scope so DistributionStack can access it (e.g. for future
-    // direct construct references with crossRegionReferences). The WAF ARN is passed via SSM.
-    if (edgeStack) {
-      this.waitingRoomEdgeStack = edgeStack;
+      // Bind edge stack reference on scope so DistributionStack can access it (e.g. for future
+      // direct construct references with crossRegionReferences). The WAF ARN is passed via SSM.
+      if (edgeStack) {
+        this.waitingRoomEdgeStack = edgeStack;
+      }
     }
 
     const distributionStack = await this.addStack('distributionStack', createDistributionStack);

--- a/cdk.json
+++ b/cdk.json
@@ -99,7 +99,8 @@
       "DEPLOYMENT_NAME": "prod",
       "AWS_REGION": "ca-central-1",
       "IS_OFFLINE": "false",
-      "FAIL_FAST": "false"
+      "FAIL_FAST": "false",
+      "DEPLOY_EDGE_STACK": "false"
     },
     "local": {
       "DEPLOYMENT_NAME": "local",

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -7,15 +7,17 @@ import { provideHttpClient } from '@angular/common/http';
 import { ApiService } from './services/api.service';
 import { AuthService } from './services/auth.service';
 import { FeatureFlagService } from './services/feature-flag.service';
+import { WaitingRoomService } from './services/waiting-room.service';
 import { provideAnimations } from '@angular/platform-browser/animations';
 import { provideToastr } from 'ngx-toastr';
 
-export function initConfig(configService: ConfigService, apiService: ApiService, authService: AuthService, featureFlagService: FeatureFlagService) {
+export function initConfig(configService: ConfigService, apiService: ApiService, authService: AuthService, featureFlagService: FeatureFlagService, waitingRoomService: WaitingRoomService) {
   return async () => {
     await configService.init();
     await authService.init();
     apiService.init();
     await featureFlagService.init();
+    await waitingRoomService.loadMode2Status();
   };
 }
 
@@ -25,7 +27,7 @@ export const appConfig: ApplicationConfig = {
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(routes),
     provideAppInitializer(() => {
-      const initializerFn = (initConfig)(inject(ConfigService), inject(ApiService), inject(AuthService), inject(FeatureFlagService));
+      const initializerFn = (initConfig)(inject(ConfigService), inject(ApiService), inject(AuthService), inject(FeatureFlagService), inject(WaitingRoomService));
       return initializerFn();
     }),
     provideAnimations(),

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -49,7 +49,8 @@ export const routes: Routes = [
   {
     path: 'cart',
     loadComponent: () => import('./cart/cart.component')
-      .then(mod => mod.CartComponent)
+      .then(mod => mod.CartComponent),
+    canActivate: [WaitingRoomGuard]
   },
   {
     path: 'checkout',
@@ -63,6 +64,7 @@ export const routes: Routes = [
       .then(mod => mod.FacilityDetailsComponent),
     resolve: { facility: FacilityResolver },
     runGuardsAndResolvers: 'always',
+    canActivate: [WaitingRoomGuard]
   },
   {
     path: 'find-booking',

--- a/src/app/guards/waiting-room.guard.ts
+++ b/src/app/guards/waiting-room.guard.ts
@@ -1,7 +1,9 @@
 import { Injectable } from '@angular/core';
-import { CanActivate } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
 import { CartService } from '../services/cart.service';
 import { WaitingRoomService } from '../services/waiting-room.service';
+
+const MODE2_FACILITY_KEY = 'MODE2#global#1';
 
 @Injectable({ providedIn: 'root' })
 export class WaitingRoomGuard implements CanActivate {
@@ -10,12 +12,29 @@ export class WaitingRoomGuard implements CanActivate {
     private waitingRoomService: WaitingRoomService
   ) {}
 
-  canActivate(): boolean {
+  canActivate(_route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean {
+    // --- Mode 2 (site-wide gate) ---
+    if (this.waitingRoomService.mode2Active()) {
+      if (this.waitingRoomService.hasValidAdmission(MODE2_FACILITY_KEY, '')) {
+        return true;
+      }
+      if (sessionStorage.getItem('wr_bypass_guard') === '1') {
+        sessionStorage.removeItem('wr_bypass_guard');
+        return true;
+      }
+      const today = new Date().toISOString().slice(0, 10);
+      window.location.href = this.waitingRoomService.buildWaitingRoomUrl(
+        'MODE2', 'global', '1', today, state.url
+      );
+      return false;
+    }
+
+    // --- Mode 1 (per-facility gate) ---
     const items = this.cartService.items();
     const waitingRoomItem = items.find(item => item.waitingRoomActive);
 
     if (!waitingRoomItem) {
-      return true; // No waiting room required for any cart item
+      return true;
     }
 
     const facilityKey = `${waitingRoomItem.collectionId}#${waitingRoomItem.activityType}#${waitingRoomItem.activityId}`;
@@ -25,13 +44,11 @@ export class WaitingRoomGuard implements CanActivate {
       return true;
     }
 
-    // Queue was closed — waiting room set this flag before redirecting here
     if (sessionStorage.getItem('wr_bypass_guard') === '1') {
       sessionStorage.removeItem('wr_bypass_guard');
       return true;
     }
 
-    // No valid admission — send user back to the waiting room
     window.location.href = this.waitingRoomService.buildWaitingRoomUrl(
       waitingRoomItem.collectionId,
       waitingRoomItem.activityType,

--- a/src/app/services/waiting-room.service.ts
+++ b/src/app/services/waiting-room.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, signal } from '@angular/core';
 import { lastValueFrom } from 'rxjs';
 import { ApiService } from './api.service';
 
@@ -13,7 +13,23 @@ export interface AdmissionContext {
 export class WaitingRoomService {
   private readonly STORAGE_KEY = 'wr_admission';
 
+  /** True when a Mode 2 (site-wide) queue is currently active. */
+  public mode2Active = signal<boolean>(false);
+
   constructor(private apiService: ApiService) {}
+
+  /** Called once at app startup to hydrate the mode2Active signal. */
+  async loadMode2Status(): Promise<void> {
+    try {
+      const res: any = await lastValueFrom(
+        this.apiService.get('waiting-room/mode2/status', {})
+      );
+      this.mode2Active.set(res?.data?.active === true);
+    } catch {
+      // Fail open — if the status check errors, don't block the whole app.
+      this.mode2Active.set(false);
+    }
+  }
 
   getAdmission(): AdmissionContext | null {
     try {


### PR DESCRIPTION
Closes the SPA navigation gap — loads Mode 2 status at startup, updates WaitingRoomGuard to handle Mode 2, adds guard to `/facility` and `/cart` routes. Depends on bcgov/reserve-rec-api#353.