### PR TITLE
fix(waiting-room): show facility display name instead of raw IDs

### DIFF
--- a/src/app/activity-details/activity-details.component.ts
+++ b/src/app/activity-details/activity-details.component.ts
@@ -137,7 +137,8 @@ export class ActivityDetailsComponent implements OnInit, AfterContentChecked, On
         this.activityType || '',
         this.activityId || '',
         this.getStartDate() || '',
-        '/checkout'
+        '/checkout',
+        this.data?.geozone?.displayName || this.data?.displayName || ''
       );
       return;
     }

--- a/src/app/facility-details/facility-details.component.ts
+++ b/src/app/facility-details/facility-details.component.ts
@@ -275,7 +275,8 @@ export class FacilityDetailsComponent implements OnDestroy {
               this.selectedActivityType,
               this.selectedActivityId,
               date,
-              this.router.url
+              this.router.url,
+              this.facility?.displayName || ''
             );
             return;
           }

--- a/src/app/services/waiting-room.service.ts
+++ b/src/app/services/waiting-room.service.ts
@@ -75,8 +75,9 @@ export class WaitingRoomService {
     }
   }
 
-  buildWaitingRoomUrl(collectionId: string, activityType: string, activityId: string, startDate: string, returnUrl: string): string {
-    const params = new URLSearchParams({ collectionId, activityType, activityId, startDate, returnUrl });
-    return `/waitingroom.html?${params.toString()}`;
+  buildWaitingRoomUrl(collectionId: string, activityType: string, activityId: string, startDate: string, returnUrl: string, facilityName?: string): string {
+    const p: Record<string, string> = { collectionId, activityType, activityId, startDate, returnUrl };
+    if (facilityName) p['facilityName'] = facilityName;
+    return `/waitingroom.html?${new URLSearchParams(p).toString()}`;
   }
 }

--- a/src/waitingroom.js
+++ b/src/waitingroom.js
@@ -87,11 +87,10 @@
   }
 
   function getFacilityDisplay(params) {
-    if (!params) return '';
-    var parts = [params.collectionId, params.activityType].filter(Boolean);
-    var label = parts.join(' / ');
-    if (params.startDate) label += ' — ' + params.startDate;
-    return label;
+    var p = new URLSearchParams(window.location.search);
+    var facilityName = p.get('facilityName');
+    if (facilityName) return facilityName;
+    return '';
   }
 
   function getReturnUrl() {


### PR DESCRIPTION
Pass `facilityName` as a URL param when redirecting to the waiting room. The waiting room page reads it and displays the park name instead of raw `bcparks_7 / dayuse — 2026-04-10` identifiers.