### PR TITLE
fix: resolve WAF origin-verify secret at deploy time, not synth time

### DIFF
--- a/lib/distribution-stack/distribution-stack.js
+++ b/lib/distribution-stack/distribution-stack.js
@@ -212,7 +212,7 @@ class DistributionStack extends BaseStack {
     // });
 
     // Look up shared secret for X-Origin-Verify header (enforced by WAF on the API Gateway stage)
-    const originVerifySecret = ssm.StringParameter.valueFromLookup(
+    const originVerifySecret = ssm.StringParameter.valueForStringParameter(
       this,
       `/reserveRecApi/${this.getDeploymentName()}/originVerifySecret`
     );


### PR DESCRIPTION
Switch `valueFromLookup` to `valueForStringParameter` so CloudFormation resolves the `originVerifySecret` SSM value at deploy time rather than synth time.

Companion to bcgov/reserve-rec-api#367.