### PR TITLE
fix: skip WaitingRoomEdgeStack for dev and test environments

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -87,13 +87,15 @@
       "DEPLOYMENT_NAME": "dev",
       "AWS_REGION": "ca-central-1",
       "IS_OFFLINE": "false",
-      "FAIL_FAST": "false"
+      "FAIL_FAST": "false",
+      "DEPLOY_EDGE_STACK": "false"
     },
     "test": {
       "DEPLOYMENT_NAME": "test",
       "AWS_REGION": "ca-central-1",
       "IS_OFFLINE": "false",
-      "FAIL_FAST": "false"
+      "FAIL_FAST": "false",
+      "DEPLOY_EDGE_STACK": "false"
     },
     "prod": {
       "DEPLOYMENT_NAME": "prod",


### PR DESCRIPTION
The edge stack deploys to us-east-1, which is blocked by org SCP p-0olid24c for the GitHub OIDC role. Dev and test don't use the edge lambda, so skip it the same way prod already does via `DEPLOY_EDGE_STACK: "false"`.