### PR TITLE
fix(waiting-room): use stable name for Mode 2 CloudFront function

### DIFF
--- a/cdk.json
+++ b/cdk.json
@@ -87,13 +87,15 @@
       "DEPLOYMENT_NAME": "dev",
       "AWS_REGION": "ca-central-1",
       "IS_OFFLINE": "false",
-      "FAIL_FAST": "false"
+      "FAIL_FAST": "false",
+      "DEPLOY_EDGE_STACK": "false"
     },
     "test": {
       "DEPLOYMENT_NAME": "test",
       "AWS_REGION": "ca-central-1",
       "IS_OFFLINE": "false",
-      "FAIL_FAST": "false"
+      "FAIL_FAST": "false",
+      "DEPLOY_EDGE_STACK": "false"
     },
     "prod": {
       "DEPLOYMENT_NAME": "prod",

--- a/lib/distribution-stack/distribution-stack.js
+++ b/lib/distribution-stack/distribution-stack.js
@@ -325,6 +325,7 @@ class DistributionStack extends BaseStack {
       ].join('\n');
 
       this.waitingRoomViewerFn = new cloudfront.Function(this, this.getConstructId('waitingRoomViewerFn'), {
+        functionName: `ReserveRecPublic-${this.getDeploymentName()}-WaitingRoomViewerFn`,
         runtime: cloudfront.FunctionRuntime.JS_2_0,
         code: cloudfront.FunctionCode.fromInline(passThrough),
         comment: `WR Mode 2 viewer-request gate for ${this.getDeploymentName()} — toggle via admin API`,


### PR DESCRIPTION
Without an explicit `functionName`, CDK generates a name with a random suffix that changes whenever the construct tree shifts. This caused the admin `toggle-mode2` Lambda's `VIEWER_FUNCTION_NAME` env var to drift and point to a non-existent function after redeployment.

New stable name: `ReserveRecPublic-{env}-WaitingRoomViewerFn`

Ref #448