### PR TITLE
PRDT: 467

### DIFF
--- a/src/app/reservation-flow/reservation-flow.component.ts
+++ b/src/app/reservation-flow/reservation-flow.component.ts
@@ -557,6 +557,6 @@ async onStepCompleted(completed: boolean): Promise<void> {
     if (this.cancelModalInstance) {
       this.cancelModalInstance.hide();
     }
-    this.router.navigate(['/cart']);
+    window.location.assign('/');
   }
 }


### PR DESCRIPTION
Ticket: [467](https://github.com/orgs/bcgov/projects/49/views/2?pane=issue&itemId=182166882&issue=bcgov%7Creserve-rec-public%7C467)

Notes: 

Cancelling mid reservation would previously route user to cart page (which is now defunct). Instead start kick to home page. 
Returning availability will be handled by the incompleteBookingScraper. Is there reason for us to trigger that process manually for the specific booking flow when cancelled? 