### PR TITLE
feat(infra): add CloudFront behavior for email asset hosting

### DIFF
--- a/lib/cdk/cloudfront.js
+++ b/lib/cdk/cloudfront.js
@@ -56,6 +56,17 @@ function cloudFrontSetup(scope, props) {
         viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
         responseHeadersPolicy: cloudfront.ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS_AND_SECURITY_HEADERS,
       },
+      '/email-assets/*': {
+        origin: origins.S3BucketOrigin.withOriginAccessControl(props.reserveRecPublicDistBucket, {
+          originPath: '/email-assets',
+          originAccessControl: reserveRecOAC,
+        }),
+        allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+        cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD,
+        viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+        cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+        responseHeadersPolicy: cloudfront.ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS,
+      },
     },
     /**
      * Belarus, Central African Republic, China, Democratic Republic of the Congo, Iran, Iraq, Democratic


### PR DESCRIPTION
Adds a `/email-assets/*` behavior to the public CloudFront distribution, serving from the existing `reserveRecPublicDistBucket` at `originPath: /email-assets`. No new bucket or IAM resources — reuses the existing OAC. Icons uploaded to `email-assets/` in the bucket are then referenceable as absolute HTTPS URLs in Cognito and SES email templates.

Ref #332