### PR TITLE
feat(infra): add CloudFront behavior for email asset hosting

### DIFF
--- a/lib/distribution-stack/distribution-stack.js
+++ b/lib/distribution-stack/distribution-stack.js
@@ -255,6 +255,16 @@ class DistributionStack extends BaseStack {
           viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
           responseHeadersPolicy: cloudfront.ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS_AND_SECURITY_HEADERS,
         },
+        '/email-assets/*': {
+          origin: origins.S3BucketOrigin.withOriginAccessControl(distBucketForOrigin, {
+            originAccessControl: this.originAccessControl,
+          }),
+          allowedMethods: cloudfront.AllowedMethods.ALLOW_GET_HEAD_OPTIONS,
+          cachedMethods: cloudfront.CachedMethods.CACHE_GET_HEAD,
+          viewerProtocolPolicy: cloudfront.ViewerProtocolPolicy.REDIRECT_TO_HTTPS,
+          cachePolicy: cloudfront.CachePolicy.CACHING_OPTIMIZED,
+          responseHeadersPolicy: cloudfront.ResponseHeadersPolicy.CORS_ALLOW_ALL_ORIGINS,
+        },
       },
       /**
            * Belarus, Central African Republic, China, Democratic Republic of the Congo, Iran, Iraq, Democratic


### PR DESCRIPTION
Supersedes #477 (which deployed to the wrong stack — `reserve-rec-public-stack.js` instead of `distribution-stack.js`).

Adds `/email-assets/*` to the `DistributionStack` CloudFront distribution using the existing `distBucketForOrigin` and OAC. No origin path — files uploaded to `email-assets/` in the dist bucket are directly accessible at `https://<cloudfront-domain>/email-assets/<filename>`.

Ref #332