### PR TITLE
fix(auth): clear jwtToken and Authorization header on logout

### DIFF
--- a/src/app/services/api.service.ts
+++ b/src/app/services/api.service.ts
@@ -67,6 +67,11 @@ export class ApiService implements OnDestroy {
     if (this.token) {
       this.headers = this.headers.set('Authorization', `Bearer ${this.token}`);
       console.log('Using JWT token auth');
+    } else {
+      // Drop a previously-set Authorization so headers track the current auth state
+      // (e.g. after logout). Without this, the Bearer from the last logged-in request
+      // would persist on this.headers and be sent on subsequent unauthenticated calls.
+      this.headers = this.headers.delete('Authorization');
     }
   }
 

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -193,6 +193,7 @@ export class AuthService {
     await signOut();
     this.updateUser(null);
     this.session.set(null);
+    this.jwtToken = null;
     console.log('User logged out', this.user);
     this.router.navigate(['/']);
   }


### PR DESCRIPTION
- `AuthService.logout()` left `this.jwtToken` populated; `ApiService.updateHeaders()` only ever **added** `Authorization`, never removed it
- After login → logout, requests kept sending the previous Bearer token, so auth-aware endpoints (e.g. facility/browse) still returned the logged-in response
- Fix: clear `jwtToken` in `logout()`, and have `updateHeaders()` delete `Authorization` when no token is present so headers track the current auth state

Ref #415