### PR TITLE
fix(cart): prompt before replacing pending booking on Book

### DIFF
--- a/src/app/activity-details/activity-details.component.spec.ts
+++ b/src/app/activity-details/activity-details.component.spec.ts
@@ -18,6 +18,7 @@ import { ConfigService } from '../services/config.service';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideToastr } from 'ngx-toastr';
+import { BsModalService } from 'ngx-bootstrap/modal';
 
 describe('ActivityDetailsComponent', () => {
   let component: ActivityDetailsComponent;
@@ -31,7 +32,8 @@ describe('ActivityDetailsComponent', () => {
         provideRouter([{ path: 'activity/:orcs/:activityType/:identifier', component: ActivityDetailsComponent }]),
         provideHttpClient(),
         provideHttpClientTesting(),
-        provideToastr()
+        provideToastr(),
+        { provide: BsModalService, useValue: { show: () => ({}) } }
       ]
     })
       .overrideComponent(ActivityDetailsComponent, {

--- a/src/app/activity-details/activity-details.component.ts
+++ b/src/app/activity-details/activity-details.component.ts
@@ -13,6 +13,8 @@ import { CartService, CartItem } from '../services/cart.service';
 import { ToastService, ToastTypes } from '../services/toast.service';
 import { WaitingRoomService } from '../services/waiting-room.service';
 import { Subscription } from 'rxjs';
+import { BsModalService } from 'ngx-bootstrap/modal';
+import { ConfirmationModalComponent } from '../shared/components/confirmation-modal/confirmation-modal.component';
 
 
 @Component({
@@ -34,6 +36,7 @@ export class ActivityDetailsComponent implements OnInit, AfterContentChecked, On
   private cartService = inject(CartService);
   private toastService = inject(ToastService);
   private waitingRoomService = inject(WaitingRoomService);
+  private modalService = inject(BsModalService);
   public isSubmitting = signal(false);
   private dateRangeSub: Subscription | null = null;
   
@@ -93,7 +96,7 @@ export class ActivityDetailsComponent implements OnInit, AfterContentChecked, On
   }
 
 
- submit(): void {
+ async submit(): Promise<void> {
     if (!this.form?.valid || this.isSubmitting()) return;
 
     this.isSubmitting.set(true);
@@ -128,6 +131,15 @@ export class ActivityDetailsComponent implements OnInit, AfterContentChecked, On
       waitingRoomActive: !!this.data?.waitingRoomActive,
     };
 
+    const existing = this.cartService.items()[0];
+    if (existing) {
+      const proceed = await this.confirmReplaceCart(existing);
+      if (!proceed) {
+        this.isSubmitting.set(false);
+        return;
+      }
+    }
+
     this.cartService.addToCart(cartItem);
 
     // If waiting room is active, redirect there now that the cart item is in place
@@ -161,6 +173,37 @@ export class ActivityDetailsComponent implements OnInit, AfterContentChecked, On
       this.isSubmitting.set(false);
     }, 2000);
     }
+
+  // Prompt the user before replacing an existing cart item. Resolves true if they
+  // confirm, false if they cancel or dismiss. Single-item cart semantics — see
+  // CartService.addToCart.
+  private confirmReplaceCart(existing: CartItem): Promise<boolean> {
+    return new Promise(resolve => {
+      const description = existing.activityName
+        ? `${existing.activityName} (${existing.startDate})`
+        : `your pending booking on ${existing.startDate}`;
+      const modalRef = this.modalService.show(ConfirmationModalComponent, {
+        initialState: {
+          title: 'Replace pending booking?',
+          body: `Your cart already has ${description}. Adding this booking will replace it.`,
+          confirmText: 'Replace',
+          cancelText: 'Cancel',
+          confirmClass: 'btn btn-primary',
+          cancelClass: 'btn btn-outline-secondary',
+        },
+      });
+      let settled = false;
+      const settle = (value: boolean) => {
+        if (settled) return;
+        settled = true;
+        modalRef.hide();
+        resolve(value);
+      };
+      modalRef.content?.confirmButton.subscribe(() => settle(true));
+      modalRef.content?.cancelButton.subscribe(() => settle(false));
+      modalRef.onHide?.subscribe(() => settle(false));
+    });
+  }
 
 
   getStartDate() {

--- a/src/app/facility-details/facility-details.component.spec.ts
+++ b/src/app/facility-details/facility-details.component.spec.ts
@@ -18,6 +18,7 @@ import { ConfigService } from '../services/config.service';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { provideToastr } from 'ngx-toastr';
+import { BsModalService } from 'ngx-bootstrap/modal';
 
 describe('FacilityDetailsComponent', () => {
   let component: FacilityDetailsComponent;
@@ -32,6 +33,7 @@ describe('FacilityDetailsComponent', () => {
         provideHttpClient(),
         provideHttpClientTesting(),
         provideToastr(),
+        { provide: BsModalService, useValue: { show: () => ({}) } },
         {
           provide: ActivatedRoute,
           useValue: {

--- a/src/app/facility-details/facility-details.component.ts
+++ b/src/app/facility-details/facility-details.component.ts
@@ -14,6 +14,8 @@ import { AuthService } from '../services/auth.service';
 import { WaitingRoomService } from '../services/waiting-room.service';
 import { ApiService } from '../services/api.service';
 import { BreadcrumbComponent } from '../shared/breadcrumb/breadcrumb.component';
+import { BsModalService } from 'ngx-bootstrap/modal';
+import { ConfirmationModalComponent } from '../shared/components/confirmation-modal/confirmation-modal.component';
 
 @Component({
   selector: 'app-facility-details',
@@ -59,6 +61,7 @@ export class FacilityDetailsComponent implements OnInit, OnDestroy {
   private toastService = inject(ToastService);
   private waitingRoomService = inject(WaitingRoomService);
   private apiService = inject(ApiService);
+  private modalService = inject(BsModalService);
 
   constructor(
     private route: ActivatedRoute,
@@ -369,12 +372,49 @@ export class FacilityDetailsComponent implements OnInit, OnDestroy {
       checkOutAnchor: selectedProductDate?.reservationContext?.checkOutAnchor ?? selectedProductDate?.reservationContext?.temporalAnchors?.checkOutTime,
     };
 
+    const existing = this.cartService.items()[0];
+    if (existing) {
+      const proceed = await this.confirmReplaceCart(existing);
+      if (!proceed) return;
+    }
+
     this.cartService.addToCart(cartItem);
     this.toastService.addMessage('Item added to cart', 'Success', ToastTypes.SUCCESS);
 
     this.router.navigate(['/reservation-flow']).then(() => {
       window.scrollTo(0, 0);
       this.cdr.detectChanges();
+    });
+  }
+
+  // Prompt the user before replacing an existing cart item. Resolves true if they
+  // confirm, false if they cancel or dismiss. Single-item cart semantics — see
+  // CartService.addToCart.
+  private confirmReplaceCart(existing: CartItem): Promise<boolean> {
+    return new Promise(resolve => {
+      const description = existing.productName
+        ? `${existing.productName} (${existing.startDate})`
+        : `your pending booking on ${existing.startDate}`;
+      const modalRef = this.modalService.show(ConfirmationModalComponent, {
+        initialState: {
+          title: 'Replace pending booking?',
+          body: `Your cart already has ${description}. Adding this booking will replace it.`,
+          confirmText: 'Replace',
+          cancelText: 'Cancel',
+          confirmClass: 'btn btn-primary',
+          cancelClass: 'btn btn-outline-secondary',
+        },
+      });
+      let settled = false;
+      const settle = (value: boolean) => {
+        if (settled) return;
+        settled = true;
+        modalRef.hide();
+        resolve(value);
+      };
+      modalRef.content?.confirmButton.subscribe(() => settle(true));
+      modalRef.content?.cancelButton.subscribe(() => settle(false));
+      modalRef.onHide?.subscribe(() => settle(false));
     });
   }
 

--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -48,17 +48,15 @@ export class CartService {
   readonly items = this.cartItems.asReadonly();
   readonly itemCount = computed(() => this.cartItems().length);
   
+  // The cart is single-item: a new add replaces whatever was there. The reservation
+  // flow only ever consumes cartItems[0], and there's no UI to pick from a list of
+  // pending bookings. Callers that want to warn the user before clobbering an existing
+  // item should call confirmReplaceIfNeeded() first.
   addToCart(item: CartItem): void {
     const itemWithId = { ...item, id: this.generateId() };
-    this.cartItems.update(items => {
-      // Drop any stale waiting-room-locked items before adding the new one.
-      // This enforces the single-item-per-waiting-room rule and prevents stale
-      // waitingRoomActive:true entries from triggering the guard on future visits.
-      const filtered = items.filter(i => !i.waitingRoomActive);
-      const newItems = [...filtered, itemWithId];
-      this.saveCartToStorage(newItems);
-      return newItems;
-    });
+    const newItems = [itemWithId];
+    this.cartItems.set(newItems);
+    this.saveCartToStorage(newItems);
   }
   
   removeFromCart(itemId: string): void {

--- a/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
+++ b/src/app/shared/components/confirmation-modal/confirmation-modal.component.html
@@ -2,6 +2,7 @@
   <h4 class="modal-title">{{ title }}</h4>
 </div>
 <div class="modal-body">
+  <p *ngIf="body" class="mb-3">{{ body }}</p>
   <div *ngFor="let row of details">
     <strong>{{ row.label }}:</strong><br>
     {{ row.eitherOr ? row.eitherOr(row.value) : row.value }}

--- a/src/app/shared/components/confirmation-modal/confirmation-modal.component.ts
+++ b/src/app/shared/components/confirmation-modal/confirmation-modal.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, Output, EventEmitter } from '@angular/core';
 import { Utils } from '../../../utils/utils';
-import { NgFor } from '@angular/common';
+import { NgFor, NgIf } from '@angular/common';
 
 export interface ModalRowSpec {
   label: string;
@@ -9,7 +9,7 @@ export interface ModalRowSpec {
 }
 
 @Component({
-  imports: [NgFor],
+  imports: [NgFor, NgIf],
   selector: 'app-confirmation-modal',
   templateUrl: './confirmation-modal.component.html',
   styleUrls: ['./confirmation-modal.component.scss'],


### PR DESCRIPTION
- `CartService.addToCart` replaces cart contents (single-item, matching the existing reservation-flow that only reads `cartItems[0]`)
- `facility-details` and `activity-details` show a confirm modal before replacing an existing item; cancel leaves the cart untouched
- Wires up the previously-unused `ConfirmationModalComponent` and fixes its template to render the `body` Input

Ref #470