### PR TITLE
fix(loading): close park dropdown on select and add spinner overlay

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,6 @@
 <app-header></app-header>
 <app-infinite-loading-bar></app-infinite-loading-bar>
+<app-loading-overlay></app-loading-overlay>
 
 <div class="content">
   <router-outlet />

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -3,12 +3,13 @@ import { RouterOutlet, Router, NavigationEnd } from '@angular/router';
 import { HeaderComponent } from "./header/header.component";
 import { FooterComponent } from './footer/footer.component';
 import { InfiniteLoadingBarComponent } from './infinite-loading-bar/infinite-loading-bar.component';
+import { LoadingOverlayComponent } from './shared/components/loading-overlay/loading-overlay.component';
 import { CommonModule } from '@angular/common';
 import { filter } from 'rxjs/operators';
 
 @Component({
     selector: 'app-root',
-    imports: [RouterOutlet, HeaderComponent, FooterComponent, InfiniteLoadingBarComponent, CommonModule],
+    imports: [RouterOutlet, HeaderComponent, FooterComponent, InfiniteLoadingBarComponent, LoadingOverlayComponent, CommonModule],
     templateUrl: './app.component.html',
     styleUrl: './app.component.scss'
 })

--- a/src/app/search-page/search-page.component.html
+++ b/src/app/search-page/search-page.component.html
@@ -12,7 +12,7 @@
             [placeholder]="'Select a park'"
             [dropdownClasses]="['w-100', 'grouped-picklist']"
             [dynamicPositioning]="false"
-            [autoCloseBehaviour]="'false'"
+            [autoCloseBehaviour]="'inside'"
           >
             <i
               ngdsInputPrepend

--- a/src/app/shared/components/loading-overlay/loading-overlay.component.ts
+++ b/src/app/shared/components/loading-overlay/loading-overlay.component.ts
@@ -1,0 +1,38 @@
+import { Component, effect, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { LoadingService } from '../../../services/loading.service';
+
+// Centered spinner overlay shown whenever LoadingService reports an outstanding
+// fetch. Layered on top of the slim infinite-loading-bar so users see a clear
+// signal during slow navigations (e.g. OpenSearch-backed facility resolves).
+@Component({
+  selector: 'app-loading-overlay',
+  standalone: true,
+  imports: [CommonModule],
+  template: `
+    <div *ngIf="loading()" class="loading-overlay" role="status" aria-live="polite">
+      <div class="spinner-border text-primary" aria-hidden="true"></div>
+      <span class="visually-hidden">Loading…</span>
+    </div>
+  `,
+  styles: [`
+    .loading-overlay {
+      position: fixed;
+      inset: 0;
+      background: rgba(255, 255, 255, 0.5);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      z-index: 1080;
+    }
+  `],
+})
+export class LoadingOverlayComponent {
+  loading = signal(false);
+
+  constructor(private loadingService: LoadingService) {
+    effect(() => {
+      this.loading.set(this.loadingService.getLoadingStatus());
+    });
+  }
+}


### PR DESCRIPTION
Picklist autoCloseBehaviour 'false' → 'inside' so the dropdown closes on selection. Adds a centered spinner overlay tied to LoadingService. Ref #431