### PR TITLE
fix(visitor-details): require mobile phone for SMS reminders opt-in

### DIFF
--- a/src/app/reservation-flow/components/steps/visitor-details-step/visitor-details-step.component.html
+++ b/src/app/reservation-flow/components/steps/visitor-details-step/visitor-details-step.component.html
@@ -46,16 +46,20 @@
           <div class="rounded p-4 bg-white">
             <h5 class="mb-3">Text Message Reminders Opt-in</h5>
             <div class="form-check p-3 rounded bg-light">
-              <input 
-                class="form-check-input" 
-                type="checkbox" 
+              <input
+                class="form-check-input"
+                type="checkbox"
                 id="smsReminders"
                 [(ngModel)]="smsOptIn"
+                [disabled]="!hasMobilePhone()"
                 (change)="onSmsOptInChange()"
               >
               <label class="form-check-label" for="smsReminders">
                 I would like to receive reminders via text message
               </label>
+              <p *ngIf="!hasMobilePhone()" class="small text-muted mb-0 mt-2">
+                Add a mobile phone number to your account to enable text message reminders.
+              </p>
             </div>
           </div>
         </div>

--- a/src/app/reservation-flow/components/steps/visitor-details-step/visitor-details-step.component.ts
+++ b/src/app/reservation-flow/components/steps/visitor-details-step/visitor-details-step.component.ts
@@ -25,16 +25,28 @@ export class VisitorDetailsStepComponent implements OnInit {
   @Output() stepValidated = new EventEmitter<boolean>();
   
   smsOptIn = false;
-  
+
   constructor(private stepperService: StepperService) {}
-  
+
   ngOnInit(): void {
     this.smsOptIn = Boolean(this.form?.get('smsOptIn')?.value);
+
+    // SMS reminders require a mobile phone on the account. If there isn't one,
+    // force the opt-in off so a stale 'true' from elsewhere can't sneak through.
+    if (!this.hasMobilePhone()) {
+      this.smsOptIn = false;
+      this.form?.patchValue({ smsOptIn: false }, { emitEvent: false });
+    }
 
     // Step is always valid since this screen is informational.
     // Completion is handled by the parent flow when Continue is clicked.
     this.stepperService.markStepValid(1, true);
     this.stepValidated.emit(true);
+  }
+
+  hasMobilePhone(): boolean {
+    const mobile = this.user?.['custom:mobilePhone'];
+    return typeof mobile === 'string' && mobile.trim().length > 0;
   }
   
   formatAddress(): string {


### PR DESCRIPTION
Disables the SMS reminders checkbox when the account has no mobile phone, forces smsOptIn to false in that case, and shows an inline hint. Ref #447