### PR TITLE
fix(facility-details): show sign-in prompt for logged-out users

### DIFF
--- a/src/app/facility-details/facility-details.component.html
+++ b/src/app/facility-details/facility-details.component.html
@@ -160,7 +160,7 @@
 				<div class="row mt-4 mb-2">
 					<div class="col-12 mt-3">
 						<button
-							*ngIf="facilityOpen && emailVerified"
+							*ngIf="isLoggedIn && facilityOpen && emailVerified"
 							class="disable-btn btn bg-white text-primary fw-bold rounded-1 px-4 w-100"
 							[disabled]="!this.form.get('selectedVisitors').value || !this.form.get('selectedDate').value || !this.form.get('selectedProduct').value || !this.passesAvailable"
 							(click)="submit()"
@@ -168,8 +168,26 @@
 							{{ passesAvailable ? "Book day-use pass" : "No passes available" }}
 						</button>
 
+							<div
+								*ngIf="!isLoggedIn"
+								class="alert alert-info p-3 d-flex align-items-start custom-alert"
+								role="status"
+							>
+								<div class="me-3" style="margin-top: 2px;">
+									<i class="fa-regular fa-circle-info text-primary fs-5"></i>
+								</div>
+								<div class="d-flex flex-column flex-grow-1">
+									<div class="mb-2">
+										<strong>Sign in to book a day-use pass.</strong>
+									</div>
+									<div>
+										<a routerLink="/login" class="btn btn-primary btn-sm">Sign in</a>
+									</div>
+								</div>
+							</div>
+
 						<div 
-							*ngIf="!facilityOpen"
+							*ngIf="isLoggedIn && !facilityOpen"
 							class="alert alert-danger p-3 d-flex align-items-start custom-alert"
 							role="alert"
 						>

--- a/src/app/facility-details/facility-details.component.ts
+++ b/src/app/facility-details/facility-details.component.ts
@@ -32,6 +32,7 @@ export class FacilityDetailsComponent implements OnInit, OnDestroy {
   
   public form: UntypedFormGroup;
   public facilityOpen = true;
+  public isLoggedIn = false;
   public passesAvailable = false;
   public loadingProducts = false;
   public loadingDates = false;
@@ -95,12 +96,12 @@ export class FacilityDetailsComponent implements OnInit, OnDestroy {
     // Initialize the form first so the template can bind immediately
     this.initializeForm();
 
-    // Check if the user is logged in - if so, check email verification
-    // otherwise the facility is "closed" to them
-    if (this.authService.getCurrentUser()) {
+    // Track auth state separately from facilityOpen so the template can show
+    // a "log in to book" prompt instead of the misleading "facility is closed"
+    // alert (issue #465).
+    this.isLoggedIn = !!this.authService.getCurrentUser();
+    if (this.isLoggedIn) {
       await this.checkUserEmailVerification();
-    } else {
-      this.facilityOpen = false;
     }
 
 


### PR DESCRIPTION
Component was setting facilityOpen=false when no user signed in, making the template render "This facility is closed." Track login state separately and show a "Sign in to book" message instead. Ref #465