### PR TITLE
fix(activity-details): set productName on cart item

### DIFF
--- a/src/app/activity-details/activity-details.component.ts
+++ b/src/app/activity-details/activity-details.component.ts
@@ -106,6 +106,10 @@ export class ActivityDetailsComponent implements OnInit, AfterContentChecked, On
       geoZoneName: this.data?.geozone?.displayName,
       activityId: this.activityId || '',
       activityName: this.data?.displayName || 'Activity',
+      // Activity-only flow has no separate product, so the pass type displayed
+      // on the checkout step is the activity name. Without this the confirm
+      // step rendered "Product Name Unavailable".
+      productName: this.data?.displayName || 'Activity',
       collectionId: this.collectionId || '',
       activityType: this.activityType || '',
       dateRange: this.form.get('dateRange')?.value || ['', ''],


### PR DESCRIPTION
Activity-only booking flow built a cart item without productName. The confirm-details step rendered the "Product Name Unavailable" fallback. Activities have no separate product so productName = activity displayName. Addresses item #2 of #471. Ref #471