### PR TITLE
fix(checkout): sentence-case Pass type and gray upcoming step tabs

### DIFF
--- a/src/app/reservation-flow/components/progress-indicator/progress-indicator.component.html
+++ b/src/app/reservation-flow/components/progress-indicator/progress-indicator.component.html
@@ -85,6 +85,7 @@
             [class.active]="step.isActive"
             [class.completed]="isStepCompletedForCurrentItem(step, i)"
             [class.text-primary]="step.isActive"
+            [class.disabled]="!step.isActive && !isStepCompletedForCurrentItem(step, i)"
             (click)="onStepClick(i)"
           >
             <!-- Step Number and Title on same line, left-aligned -->

--- a/src/app/reservation-flow/components/progress-indicator/progress-indicator.component.scss
+++ b/src/app/reservation-flow/components/progress-indicator/progress-indicator.component.scss
@@ -43,6 +43,14 @@
 .nav-link.disabled {
   opacity: 0.6;
   cursor: not-allowed;
+  color: #6c757d !important; // upcoming steps render gray instead of inheriting blue
+
+  // Inner text/numbers inherit the muted colour even when text-primary is on
+  // the parent — Angular template applies it conditionally based on isActive.
+  span,
+  i {
+    color: inherit !important;
+  }
 }
 
 @media (max-width: 768px) {

--- a/src/app/reservation-flow/components/steps/confirm-details-step/confirm-details-step.component.html
+++ b/src/app/reservation-flow/components/steps/confirm-details-step/confirm-details-step.component.html
@@ -50,7 +50,7 @@
           <div class="row">
             <div class="col-md-6 mb-3 mb-md-0">
               <div class="rounded p-3">
-                <h6 class="text-muted mb-2 fw-semibold">Pass Type</h6>
+                <h6 class="text-muted mb-2 fw-semibold">Pass type</h6>
                 <p class="mb-0 fw-medium"><i class="fa-regular fa-location-dot me-2"></i>{{ cartItem?.productName || 'Product Name Unavailable' }}</p>
               </div>
             </div>


### PR DESCRIPTION
Addresses items #3 and #4 of #471: "Pass type" sentence case + apply .disabled class to upcoming step tabs so they render gray until reached. Item #1 (arrival/departure times) needs API shape investigation, deliberately not in this PR. Ref #471