### PR TITLE
fix(facility-details): surface API booking errors to the toast

### DIFF
--- a/src/app/facility-details/facility-details.component.ts
+++ b/src/app/facility-details/facility-details.component.ts
@@ -415,7 +415,15 @@ export class FacilityDetailsComponent implements OnInit, OnDestroy {
       });
     } catch (error: any) {
       console.error('Error creating booking:', error);
-      const errorMessage = error?.error?.message || error?.message || 'Failed to create booking. Please try again.';
+      // API returns error text under `msg`; walk the usual shapes before
+      // falling back to a generic message.
+      const errorMessage =
+        error?.error?.msg ||
+        error?.error?.error ||
+        error?.error?.Message ||
+        error?.error?.message ||
+        error?.message ||
+        'Failed to create booking. Please try again.';
       this.toastService.addMessage(errorMessage, 'Error', ToastTypes.ERROR);
     }
   }


### PR DESCRIPTION
The booking-creation error toast wasn't reaching the user with the BE's actual message — including the duplicate-booking 409 introduced for #458. Cause: the walker looked for `error.error.message`, but the API serialises the user-facing string under `error.error.msg`.

Match the walker pattern already used in `product.service.ts` (msg → error → Message → message → fallback).

Ref #458