### PR TITLE
fix(footer): keep legal links on one row at sm viewports

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -49,16 +49,16 @@
             </nav>
         </div>
         <nav aria-label="Legal links" class="bottom-box-content d-flex flex-wrap justify-content-start align-items-start gap-5 gap-md-5 gap-lg-5 mx-auto my-4 mb-5 border-1 border-top border-info pt-4 justify-content-lg-center justify-content-md-center">
-            <div class="d-flex flex-column flex-md-row gap-md-5 gap-lg-5">
-                <a href="https://www2.gov.bc.ca/gov/content/home/disclaimer" class="mt-2 mb-2 mb-lg-0 mb-md-0">
+            <div class="d-flex flex-column flex-sm-row gap-sm-5 gap-md-5 gap-lg-5">
+                <a href="https://www2.gov.bc.ca/gov/content/home/disclaimer" class="mt-2 mb-2 mb-lg-0 mb-md-0 mb-sm-0">
                     Disclaimer
                 </a>
                 <a href="https://www2.gov.bc.ca/gov/content/home/accessible-government" class="mt-2">
                     Accessibility
                 </a>
             </div>
-            <div class="d-flex flex-column flex-md-row gap-md-5 gap-lg-5">
-                <a href="https://www2.gov.bc.ca/gov/content/home/privacy" class="mt-2 mb-2 mb-lg-0 mb-md-0">
+            <div class="d-flex flex-column flex-sm-row gap-sm-5 gap-md-5 gap-lg-5">
+                <a href="https://www2.gov.bc.ca/gov/content/home/privacy" class="mt-2 mb-2 mb-lg-0 mb-md-0 mb-sm-0">
                     Privacy
                 </a>
                 <a href="https://www2.gov.bc.ca/gov/content/home/copyright" class="mt-2">


### PR DESCRIPTION
At 744px (the tablet viewport called out in the bug), the four legal links — Disclaimer / Accessibility / Privacy / Copyright — stacked vertically because the inner flex groups used `flex-md-row` (>=768px). Drop the breakpoint to `sm` so the row layout activates from 576px up.

Issue is filed in the admin repo by mistake; the screenshot, URL, and link names all point at the public footer.

Ref bcgov/reserve-rec-public#525