### PR TITLE
fix(cart): run the initial sub-load on first effect tick

### DIFF
--- a/src/app/services/cart.service.ts
+++ b/src/app/services/cart.service.ts
@@ -52,7 +52,11 @@ export class CartService {
 
   private authService = inject(AuthService);
   private cartItems = signal<CartItem[]>([]);
-  private currentSub: string | null = null;
+  // `undefined` sentinel so the first effect run is not mistaken for "no
+  // change" when the auth user signal starts at null. After the first run
+  // this holds the actual sub (or null for anon) and subsequent same-user
+  // ticks short-circuit normally.
+  private currentSub: string | null | undefined = undefined;
 
   // Public readonly signals
   readonly items = this.cartItems.asReadonly();


### PR DESCRIPTION
### Ticket:

bcgov/reserve-rec-public#503

### Ticket URL:

https://github.com/bcgov/reserve-rec-public/issues/503

### Description:

- Follow-up to #518: the sub-keyed cart effect short-circuited on its first tick because both `currentSub` and the initial auth user signal were `null`, so the equality check returned true and the storage load (including the legacy-key migration) never ran on a fresh session.
- Use `undefined` as the sentinel for "no run yet" — first tick always proceeds, subsequent same-user ticks still short-circuit.
- Verified on dev: visiting \`/cart\` with a legacy \`bcparks-cart\` key in localStorage now correctly migrates to \`bcparks-cart::anon\`.

Ref bcgov/reserve-rec-public#503