### PR TITLE
fix(booking): drop user identity fields from booking payload

### DIFF
--- a/src/app/reservation-flow/components/steps/payment-step/payment-step.component.ts
+++ b/src/app/reservation-flow/components/steps/payment-step/payment-step.component.ts
@@ -175,20 +175,19 @@ export class PaymentStepComponent implements OnInit {
   }
 
   getNamedOccupantInformation() {
-    const userIsOccupant = this.form.get('userIsPrimaryOccupant').value;
-    const accountMobilePhone = this.user?.['custom:mobilePhone'] || this.user?.phone_number || '';
-    const obj = {
-      firstName: userIsOccupant ? this.user?.given_name || '' : this.form.get('primaryOccupant.firstName').value,
-      lastName: userIsOccupant ? this.user?.family_name || '' : this.form.get('primaryOccupant.lastName').value,
+    // Identity fields (firstName, lastName, email, mobilePhone) are resolved
+    // server-side from the authenticated Cognito sub — the FE must not send
+    // them or the booking can be made to carry another user's identity
+    // (Ref #480). Address fields stay client-provided since Cognito does not
+    // reliably carry them for BCSC users.
+    const obj: any = {
       contactInfo: {
-        email: userIsOccupant ? this.user?.email || '' : this.form.get('primaryOccupant.email').value,
-        mobilePhone: userIsOccupant ? accountMobilePhone : this.form.get('primaryOccupant.phoneNumber').value,
-        streetAddress: userIsOccupant ? this.user?.address?.streetAddress || '' : this.form.get('addressInfo.streetAddress').value,
-        unitNumber: userIsOccupant ? this.user?.address?.unitNumber || '' : this.form.get('addressInfo.unitNumber').value,
-        postalCode: userIsOccupant ? this.user?.address?.postalCode || '' : this.form.get('addressInfo.postalCode').value,
-        city: userIsOccupant ? this.user?.address?.city || '' : this.form.get('addressInfo.city').value,
-        province: userIsOccupant ? this.user?.address?.province || '' : this.form.get('addressInfo.province').value,
-        country: userIsOccupant ? this.user?.address?.country || '' : this.form.get('addressInfo.country').value,
+        streetAddress: this.user?.address?.streetAddress || this.form.get('addressInfo.streetAddress')?.value || '',
+        unitNumber: this.user?.address?.unitNumber || this.form.get('addressInfo.unitNumber')?.value || '',
+        postalCode: this.user?.address?.postalCode || this.form.get('addressInfo.postalCode')?.value || '',
+        city: this.user?.address?.city || this.form.get('addressInfo.city')?.value || '',
+        province: this.user?.address?.province || this.form.get('addressInfo.province')?.value || '',
+        country: this.user?.address?.country || this.form.get('addressInfo.country')?.value || '',
       }
     };
 

--- a/src/app/reservation-flow/reservation-flow.component.ts
+++ b/src/app/reservation-flow/reservation-flow.component.ts
@@ -366,37 +366,21 @@ async onStepCompleted(completed: boolean): Promise<void> {
   }
 
   private getNamedOccupantInfo(formValue: any): any {
-    const userIsOccupant = formValue.userIsPrimaryOccupant;
-    const profile = this.getUserProfileDefaults();
-    const primaryOccupant = formValue.primaryOccupant || {};
+    // Identity fields (firstName, lastName, email, mobilePhone) are resolved
+    // server-side from the authenticated Cognito sub — the FE must not send
+    // them or the booking can be made to carry another user's identity
+    // (Ref #480). Address fields stay client-provided since Cognito does not
+    // reliably carry them for BCSC users.
     const addressInfo = formValue.addressInfo || {};
 
     return {
-      firstName: userIsOccupant ? profile.firstName : primaryOccupant.firstName || '',
-      lastName: userIsOccupant ? profile.lastName : primaryOccupant.lastName || '',
       contactInfo: {
-        email: userIsOccupant ? profile.email : primaryOccupant.email || '',
-        mobilePhone: userIsOccupant ? profile.mobilePhone : primaryOccupant.phoneNumber || '',
         streetAddress: addressInfo.streetAddress || '',
         city: addressInfo.city || '',
         postalCode: addressInfo.postalCode || '',
         province: addressInfo.province || '',
         country: addressInfo.country || ''
       }
-    };
-  }
-
-  private getUserProfileDefaults(): {
-    firstName: string;
-    lastName: string;
-    email: string;
-    mobilePhone: string;
-  } {
-    return {
-      firstName: this.user?.given_name || '',
-      lastName: this.user?.family_name || '',
-      email: this.user?.email || '',
-      mobilePhone: this.user?.['custom:mobilePhone'] || this.user?.phone_number || ''
     };
   }
 


### PR DESCRIPTION
### Ticket:

#480

### Description:

- `getNamedOccupantInfo`/`getNamedOccupantInformation` no longer send `firstName`/`lastName`/`email`/`mobilePhone`; API resolves these from the authenticated Cognito sub
- Address fields stay client-provided
- Paired with bcgov/reserve-rec-api#404

Ref #480