### PR TITLE
fix(footer): single-row legal links from sm breakpoint up

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -45,23 +45,11 @@
                 </div>
             </nav>
         </div>
-        <nav aria-label="Legal links" class="bottom-box-content d-flex flex-wrap justify-content-start align-items-start gap-5 gap-md-5 gap-lg-5 mx-auto my-4 mb-5 border-1 border-top border-info pt-4 justify-content-lg-center justify-content-md-center">
-            <div class="d-flex flex-column flex-sm-row gap-sm-5 gap-md-5 gap-lg-5">
-                <a href="https://www2.gov.bc.ca/gov/content/home/disclaimer" class="mt-2 mb-2 mb-lg-0 mb-md-0 mb-sm-0">
-                    Disclaimer
-                </a>
-                <a href="https://www2.gov.bc.ca/gov/content/home/accessible-government" class="mt-2">
-                    Accessibility
-                </a>
-            </div>
-            <div class="d-flex flex-column flex-sm-row gap-sm-5 gap-md-5 gap-lg-5">
-                <a href="https://www2.gov.bc.ca/gov/content/home/privacy" class="mt-2 mb-2 mb-lg-0 mb-md-0 mb-sm-0">
-                    Privacy
-                </a>
-                <a href="https://www2.gov.bc.ca/gov/content/home/copyright" class="mt-2">
-                    Copyright
-                </a>
-            </div>
+        <nav aria-label="Legal links" class="bottom-box-content d-flex flex-column flex-sm-row flex-sm-nowrap align-items-start align-items-sm-center justify-content-sm-center gap-3 gap-md-5 mx-auto my-4 mb-5 border-1 border-top border-info pt-4">
+            <a href="https://www2.gov.bc.ca/gov/content/home/disclaimer">Disclaimer</a>
+            <a href="https://www2.gov.bc.ca/gov/content/home/accessible-government">Accessibility</a>
+            <a href="https://www2.gov.bc.ca/gov/content/home/privacy">Privacy</a>
+            <a href="https://www2.gov.bc.ca/gov/content/home/copyright">Copyright</a>
         </nav>
     </div>
 </footer>


### PR DESCRIPTION
Ticket: https://github.com/bcgov/reserve-rec-public/issues/525

### Description:
Per Manuji's design notes on #525, the four legal links should sit on a single row across the entire tablet/desktop range. PR #514 fixed the breakpoint but the two grouped wrapper divs still caused the outer flex container to wrap into two lines at 744-767px because the gap between the groups didn't fit.

Flattened the structure to four direct flex children with `gap-3` on sm and `gap-md-5` on md+, so the same single-row layout renders from 576px up while keeping the existing desktop spacing untouched. Mobile (<576px) continues to render as a vertical stack.

Verified visually at viewport widths 400, 540, 575, 576, 700, 744, 767, 768, 1000, and 1440px.