### PR TITLE
fix(footer): responsive layout at design breakpoints (540/1440)

### DIFF
--- a/src/app/footer/footer.component.html
+++ b/src/app/footer/footer.component.html
@@ -8,14 +8,13 @@
         </div>
     </div>
     <div class="bottom-box w-100">
-        <div
-            class="bottom-box-content d-flex flex-column flex-md-row justify-content-between align-items-start mx-auto my-4">
-            <div class="col-lg-4 col-md-4 col-sm-12 mb-4 me-4">
+        <div class="bottom-box-content footer-main mx-auto my-4">
+            <div class="footer-logo">
                 <img src="https://bcparks.ca/static/c162b97913df25450593199f6bbb4ea4/65626/BCParks_Wordmark_White-cropped.webp"
                     alt="BC Parks logo" class="mb-3"
                     style="width: 213px">
             </div>
-            <nav aria-label="Day-use pass" class="col-lg-4 col-md-4 col-sm-12 mb-3 border-0">
+            <nav aria-label="Day-use pass" class="footer-nav border-0">
                 <h6 class="fw-bold">Day-use pass</h6>
                 <hr class="footer-section-underline">
                 <ul>
@@ -24,7 +23,7 @@
                     </li>
                 </ul>
             </nav>
-            <nav aria-label="Stay connected" class="col-lg-4 col-md-4 col-sm-12  mb-3 border-0">
+            <nav aria-label="Stay connected" class="footer-nav border-0">
                 <h6 class="fw-bold">Stay connected</h6>
                 <hr class="footer-section-underline">
                 <ul>
@@ -45,10 +44,10 @@
                 </div>
             </nav>
         </div>
-        <nav aria-label="Legal links" class="bottom-box-content d-flex flex-column flex-sm-row flex-sm-nowrap align-items-start align-items-sm-center justify-content-sm-center gap-3 gap-md-5 mx-auto my-4 mb-5 border-1 border-top border-info pt-4">
+        <nav aria-label="Legal links" class="bottom-box-content footer-legal mx-auto my-4 mb-5 border-1 border-top border-info pt-4">
             <a href="https://www2.gov.bc.ca/gov/content/home/disclaimer">Disclaimer</a>
-            <a href="https://www2.gov.bc.ca/gov/content/home/accessible-government">Accessibility</a>
             <a href="https://www2.gov.bc.ca/gov/content/home/privacy">Privacy</a>
+            <a href="https://www2.gov.bc.ca/gov/content/home/accessible-government">Accessibility</a>
             <a href="https://www2.gov.bc.ca/gov/content/home/copyright">Copyright</a>
         </nav>
     </div>

--- a/src/app/footer/footer.component.scss
+++ b/src/app/footer/footer.component.scss
@@ -55,6 +55,76 @@ a:hover {
     text-decoration: underline;
 }
 
+// Footer responsive layout.
+//
+// The design specifies non-Bootstrap breakpoints (mobile < 540px, tablet
+// 540–1439px, desktop >= 1440px), so we drive the layout with explicit media
+// queries rather than Bootstrap's grid/flex utility classes — those snap at
+// 576/768px and were the cause of the 744px viewport rendering as mobile.
+$footer-bp-tablet: 540px;
+$footer-bp-desktop: 1440px;
+
+// --- Main content (above the divider): logo + the two nav columns ---
+.footer-main {
+    display: flex;
+    flex-direction: column; // mobile (< 540): everything stacked
+    gap: 1rem;
+}
+
+// Tablet: logo spans the full width on its own row, the two nav sections
+// sit side-by-side as two equal columns beneath it.
+@media (min-width: $footer-bp-tablet) {
+    .footer-main {
+        flex-direction: row;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        column-gap: 1.5rem;
+        row-gap: 1rem;
+    }
+
+    .footer-logo {
+        flex: 0 0 100%;
+    }
+
+    .footer-nav {
+        flex: 1 1 0;
+        min-width: 0;
+    }
+}
+
+// Desktop: the logo becomes the first of three columns in a single row.
+@media (min-width: $footer-bp-desktop) {
+    .footer-main {
+        flex-wrap: nowrap;
+    }
+
+    .footer-logo {
+        flex: 1 1 0;
+    }
+}
+
+// --- Legal links (below the divider) ---
+// Mobile: two columns, filled row-by-row. With the DOM order
+// Disclaimer, Privacy, Accessibility, Copyright this yields:
+//   Disclaimer    Privacy
+//   Accessibility Copyright
+.footer-legal {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.75rem 1.5rem;
+    justify-items: start;
+}
+
+// Tablet and up: a single centered row.
+@media (min-width: $footer-bp-tablet) {
+    .footer-legal {
+        display: flex;
+        flex-wrap: wrap;
+        justify-content: center;
+        gap: 1rem 3rem;
+    }
+}
+
 // I have decreed it that this is the best way to do this
 // and I will fight anyone who says otherwise
 @media (max-width: 767px) {


### PR DESCRIPTION
### Ticket:

#525

### Description:

Fixes the footer QA send-back. The footer used Bootstrap's grid/flex breakpoints (576/768), so a 744px viewport rendered as mobile. Layout is now driven by the design's own breakpoints via explicit media queries.

- **Mobile (<540):** main nav stacked single column; legal links in a 2×2 grid (row 1 Disclaimer / Privacy, row 2 Accessibility / Copyright).
- **Tablet (540–1439):** logo full-width, then Day-use pass + Stay connected as two columns; legal links single centered row.
- **Desktop (≥1440):** unchanged 3-across, legal links single row.
- Reordered the legal links to Disclaimer, Privacy, Accessibility, Copyright so a single DOM order produces both the single row and the mobile grid correctly (matches Figma).

Verified at 375 / 539 / 744 / 1439 / 1440 px against the Figma tablet, mobile, and desktop guides.