### PR TITLE
fix(bookings): block cancelling expired passes

### DIFF
--- a/src/app/my-bookings/booking-details/booking-details.component.html
+++ b/src/app/my-bookings/booking-details/booking-details.component.html
@@ -52,7 +52,7 @@
                       Download QR code
                     </button>
                   </li>
-                  <li *ngIf="!isCancelled()">
+                  <li *ngIf="!isCancelled() && !isExpired()">
                     <button type="button" class="dropdown-item text-danger px-4 p-3" (click)="cancelBooking()">
                       Cancel entire booking
                     </button>

--- a/src/app/my-bookings/booking-details/booking-details.component.ts
+++ b/src/app/my-bookings/booking-details/booking-details.component.ts
@@ -117,6 +117,10 @@ export class BookingDetailsComponent implements OnInit {
     return BookingUtils.isCancelled(this.booking);
   }
 
+  isExpired(): boolean {
+    return BookingUtils.isExpired(this.booking);
+  }
+
   downloadQRCode(): void {
     if (!this.qrCodeDataUrl) {
       console.warn('No QR code available to download');
@@ -138,6 +142,11 @@ export class BookingDetailsComponent implements OnInit {
   }
 
   cancelBooking(): void {
+    // Expired passes can't be cancelled — the button is hidden, but guard the
+    // handler too in case it's reached another way (#538).
+    if (this.isExpired()) {
+      return;
+    }
     const bookingId = this.route.snapshot.paramMap.get('id');
     if (bookingId) {
       this.router.navigate(['/account/bookings/cancel', bookingId]);

--- a/src/app/my-bookings/bookings-cancel/booking-cancel.component.ts
+++ b/src/app/my-bookings/bookings-cancel/booking-cancel.component.ts
@@ -89,8 +89,12 @@ constructor(
     return BookingUtils.isCancelled(this.booking);
   }
 
+  isExpired(): boolean {
+    return BookingUtils.isExpired(this.booking);
+  }
+
   showActionBar(): boolean {
-    return !this.loading && !!this.booking && !this.isBookingCancelled();
+    return !this.loading && !!this.booking && !this.isBookingCancelled() && !this.isExpired();
   }
 
   getGeozoneName(): string {
@@ -187,7 +191,7 @@ constructor(
   }
 
   async onConfirmRefund() {
-    if (!this.acknowledgeCancel || this.isBookingCancelled()) {
+    if (!this.acknowledgeCancel || this.isBookingCancelled() || this.isExpired()) {
       return;
     }
 

--- a/src/app/utils/booking-utils.spec.ts
+++ b/src/app/utils/booking-utils.spec.ts
@@ -1,0 +1,31 @@
+import { DateTime } from 'luxon';
+import { BookingUtils } from './booking-utils';
+
+const TZ = 'America/Vancouver';
+const iso = (days: number) => DateTime.now().setZone(TZ).plus({ days }).toISODate();
+
+describe('BookingUtils.isExpired (#538)', () => {
+  it('is false for a same-day pass (still usable)', () => {
+    expect(BookingUtils.isExpired({ endDate: iso(0) })).toBe(false);
+  });
+
+  it('is true for past passes', () => {
+    expect(BookingUtils.isExpired({ endDate: iso(-1) })).toBe(true);
+    expect(BookingUtils.isExpired({ endDate: iso(-30) })).toBe(true);
+  });
+
+  it('is false for future passes', () => {
+    expect(BookingUtils.isExpired({ endDate: iso(1) })).toBe(false);
+  });
+
+  it('falls back to startDate when endDate is missing', () => {
+    expect(BookingUtils.isExpired({ startDate: iso(-2) })).toBe(true);
+    expect(BookingUtils.isExpired({ startDate: iso(2) })).toBe(false);
+  });
+
+  it('fails open (not expired) for missing or invalid dates', () => {
+    expect(BookingUtils.isExpired({})).toBe(false);
+    expect(BookingUtils.isExpired(null)).toBe(false);
+    expect(BookingUtils.isExpired({ endDate: 'garbage' })).toBe(false);
+  });
+});

--- a/src/app/utils/booking-utils.ts
+++ b/src/app/utils/booking-utils.ts
@@ -49,6 +49,24 @@ export class BookingUtils {
   }
 
   /**
+   * Whether the booking date has already passed (an expired / "old" pass).
+   * Compares the end date against today in the park timezone, date-only, so a
+   * same-day pass is NOT treated as expired. Expired passes can't be cancelled.
+   */
+  static isExpired(booking: any): boolean {
+    const endDate = booking?.endDate || booking?.startDate;
+    if (!endDate) {
+      return false;
+    }
+    const end = DateTime.fromISO(String(endDate), { zone: 'America/Vancouver' }).startOf('day');
+    if (!end.isValid) {
+      return false;
+    }
+    const today = DateTime.now().setZone('America/Vancouver').startOf('day');
+    return end < today;
+  }
+
+  /**
    * Get formatted arrival/check-in time
    */
   static getArrivalTime(booking: any): string {


### PR DESCRIPTION
### Ticket:

#538

### Description:

Expired/old passes could still be cancelled from My Bookings. Adds `BookingUtils.isExpired` (endDate before today, park tz, date-only — same-day stays cancellable) and hides/guards the cancel action on both the booking-details page and the cancel confirmation page (so direct navigation can't bypass it). Includes unit tests.

Note: frontend fix — suggest a follow-up so the API cancel endpoint also rejects expired bookings.