### PR TITLE
fix(bookings): correct cancelled notice icon + copy

### DIFF
--- a/src/app/my-bookings/bookings-cancel/booking-cancel.component.html
+++ b/src/app/my-bookings/bookings-cancel/booking-cancel.component.html
@@ -43,8 +43,8 @@
         <div class="card-body p-4">
           <ng-container *ngIf="isBookingCancelled()"> 
           <div class="alert alert-danger mb-4" role="alert">
-              <i class="fa-solid fa-triangle-exclamation text-danger me-2"></i>
-              <strong class="text-dark">This reservation has been cancelled.</strong>
+              <i class="fa-regular fa-circle-exclamation text-danger me-2"></i>
+              <strong class="text-dark">This booking has been cancelled</strong>
             </div>
             </ng-container>
 


### PR DESCRIPTION
### Ticket:

#560

### Description:

QA follow-up: the cancelled notice on the cancellation confirmation page now uses the red circle-exclamation icon per Figma (was a triangle), and the copy reads "This booking has been cancelled".