### PR TITLE
fix(bookings): hide actions, info notice and QR for past bookings

### DIFF
--- a/src/app/my-bookings/booking-details/booking-details.component.html
+++ b/src/app/my-bookings/booking-details/booking-details.component.html
@@ -34,8 +34,8 @@
       <!-- Success Content -->
       <div *ngIf="!loading && !error && booking">
 
-        <!-- Actions Section -->
-        <div *ngIf="!isCancelled()" class="mb-4 p-0">
+        <!-- Actions Section (hidden for cancelled or past bookings) -->
+        <div *ngIf="!isCancelled() && !isExpired()" class="mb-4 p-0">
           <div class="row">
             <div class="col-lg-3 col-md-5 col-12 my-2">
               <div class="dropdown d-grid">
@@ -85,7 +85,7 @@
 
         <!-- Info Section -->
         <div class="d-flex flex-column">
-          <div class="info-section alert alert-info border border-primary mb-4 p-4 text-dark d-flex align-items-start" *ngIf="!isCancelled()">
+          <div class="info-section alert alert-info border border-primary mb-4 p-4 text-dark d-flex align-items-start" *ngIf="!isCancelled() && !isExpired()">
             <div class="me-2 flex-shrink-0">
               <i class="fa-regular fa-circle-info text-primary"></i>
             </div>
@@ -185,7 +185,7 @@
         <!-- QR Code Card -->
         <div class="row">
           <div class="col-lg-9 col-12">
-            <div class="card border-1 mb-4" *ngIf="!isCancelled() && qrCodeDataUrl">
+            <div class="card border-1 mb-4" *ngIf="!isCancelled() && !isExpired() && qrCodeDataUrl">
               <div class="card-body p-4">
                 <div class="text-center">
               <div>


### PR DESCRIPTION
### Ticket:

#538

### Description:

QA follow-up to match design #557 for a past (expired) booking on the details page: hide the Actions button, the "Changes cannot be made to this booking." message, and the QR code section (all now gated on `!isExpired()`). The cancel-on-expired guard from the original fix stays.