### PR TITLE
fix(bookings): show facility name on My bookings cards

### DIFF
--- a/src/app/my-bookings/bookings-main-card/bookings-main-card.component.html
+++ b/src/app/my-bookings/bookings-main-card/bookings-main-card.component.html
@@ -4,7 +4,7 @@
       <strong class="text-primary fs-5">{{ geozoneName }}</strong>
     </div>
     <div class="text-muted mb-3 fs-5">
-      {{ productName }}
+      {{ facilityName }}
     </div>
     <div class="text-body-emphasis mb-2">
       {{ activityType }}


### PR DESCRIPTION
### Ticket:
https://github.com/bcgov/reserve-rec-public/issues/540

### Description:
- My bookings cards showed product name (activity + pass type, e.g. "Joffre Lakes Day-use Pass - All day") under the park
  name instead of the facility name.
- Swap `productName` binding for `facilityName` in `bookings-main-card.component.html`