### PR TITLE
fix(reservation-flow): fix account dropdown and ghost component on na…

### DIFF
--- a/src/app/reservation-flow/reservation-flow.component.html
+++ b/src/app/reservation-flow/reservation-flow.component.html
@@ -20,7 +20,7 @@
       <!-- Step Content Container -->
       <div class="container-fluid bg-grey p-4">
         <!-- Single step container with exclusive display logic -->
-        <ng-container [ngSwitch]="stepperService.currentStepIndex()">
+        <ng-container [ngSwitch]="currentStep">
           
           <!-- Step 0: Details -->
           <div *ngSwitchCase="0" class="step-wrapper fade-in">

--- a/src/app/reservation-flow/reservation-flow.component.ts
+++ b/src/app/reservation-flow/reservation-flow.component.ts
@@ -1,4 +1,4 @@
-import { AfterContentChecked, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit } from '@angular/core';
 import { Router, RouterModule } from '@angular/router';
 import { UntypedFormControl, UntypedFormGroup, Validators } from '@angular/forms';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
@@ -15,9 +15,9 @@ import { PaymentStepComponent } from './components/steps/payment-step/payment-st
 import { AdmissionCountdownComponent } from '../components/admission-countdown/admission-countdown.component';
 import { FeatureFlagService } from '../services/feature-flag.service';
 import { BreadcrumbComponent } from '../shared/breadcrumb/breadcrumb.component';
-import { ViewChild, ElementRef } from '@angular/core';
-import { lastValueFrom } from 'rxjs';
-import * as bootstrap from 'bootstrap';
+import { ViewChild } from '@angular/core';
+import { lastValueFrom, Subscription } from 'rxjs';
+import Modal from 'bootstrap/js/dist/modal';
 
 @Component({
   selector: 'app-reservation-flow',
@@ -36,9 +36,11 @@ import * as bootstrap from 'bootstrap';
   templateUrl: './reservation-flow.component.html',
   styleUrl: './reservation-flow.component.scss'
 })
-export class ReservationFlowComponent implements OnInit, AfterContentChecked, OnDestroy {
+export class ReservationFlowComponent implements OnInit, OnDestroy {
 
   cartItems: CartItem[] = [];
+  currentStep = 0;
+  private stepSub?: Subscription;
   public user: any = null;
   public form: UntypedFormGroup;
   public accessPointsSelectionList: any[] = [];
@@ -68,6 +70,7 @@ export class ReservationFlowComponent implements OnInit, AfterContentChecked, On
 
   constructor(
     private changeDetectorRef: ChangeDetectorRef,
+    private elementRef: ElementRef,
     public router: Router,
     public stepperService: StepperService,
     private cartService: CartService,
@@ -79,6 +82,10 @@ export class ReservationFlowComponent implements OnInit, AfterContentChecked, On
   }
 
   ngOnInit(): void {
+    this.stepperService.reset();
+    this.stepSub = this.stepperService.currentStep$.subscribe(() => {
+      this.currentStep = this.stepperService.currentStepIndex();
+    });
     this.loadCartItems();
     this.initializeForCurrentItem();
   }
@@ -439,10 +446,6 @@ async onStepCompleted(completed: boolean): Promise<void> {
     this.router.navigate(['/']);
   }
 
-  ngAfterContentChecked(): void {
-    this.changeDetectorRef.detectChanges();
-  }
-
   // Navigation bar methods
   cancelBooking(): void {
     // Now handled by modal
@@ -511,8 +514,8 @@ async onStepCompleted(completed: boolean): Promise<void> {
   }
 
   ngOnDestroy(): void {
-    this.stepperService.reset();
-    this.changeDetectorRef.detach();
+    this.stepSub?.unsubscribe();
+    this.elementRef.nativeElement.remove();
   }
 
   @ViewChild('cancelBookingModal', { static: false }) cancelBookingModal?: ElementRef;
@@ -520,7 +523,7 @@ async onStepCompleted(completed: boolean): Promise<void> {
 
   openCancelModal(): void {
     if (!this.cancelModalInstance && this.cancelBookingModal) {
-      this.cancelModalInstance = new bootstrap.Modal(this.cancelBookingModal.nativeElement);
+      this.cancelModalInstance = new Modal(this.cancelBookingModal.nativeElement);
     }
     if (this.cancelModalInstance) {
       this.cancelModalInstance.show();
@@ -528,7 +531,7 @@ async onStepCompleted(completed: boolean): Promise<void> {
       // fallback for static template
       const modalEl = document.getElementById('cancelBookingModal');
       if (modalEl) {
-        this.cancelModalInstance = new bootstrap.Modal(modalEl);
+        this.cancelModalInstance = new Modal(modalEl);
         this.cancelModalInstance.show();
       }
     }

--- a/src/app/shared/breadcrumb/breadcrumb.component.ts
+++ b/src/app/shared/breadcrumb/breadcrumb.component.ts
@@ -1,4 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, inject, OnInit } from '@angular/core';
+import { DestroyRef } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, NavigationEnd, Router, RouterModule } from '@angular/router';
 import { CommonModule } from '@angular/common';
 import { filter, distinctUntilChanged } from 'rxjs/operators';
@@ -18,6 +20,8 @@ interface Breadcrumb {
 export class BreadcrumbComponent implements OnInit {
   breadcrumbs: Breadcrumb[] = [];
 
+  private destroyRef = inject(DestroyRef);
+
   constructor(
     private router: Router,
     private activatedRoute: ActivatedRoute
@@ -26,11 +30,11 @@ export class BreadcrumbComponent implements OnInit {
   ngOnInit(): void {
     this.breadcrumbs = this.buildBreadcrumbs(this.activatedRoute.root);
 
-    // Update breadcrumbs on navigation
     this.router.events
       .pipe(
         filter(event => event instanceof NavigationEnd),
-        distinctUntilChanged()
+        distinctUntilChanged(),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(() => {
         this.breadcrumbs = this.buildBreadcrumbs(this.activatedRoute.root);


### PR DESCRIPTION
### Ticket:

https://github.com/bcgov/reserve-rec-public/issues/494

### Description:
- **Bug 1 — Account dropdown blocked on booking pages:** `import * as bootstrap` caused Bootstrap to
  double-register its `data-api` click listeners on `DOMContentLoaded`, intercepting clicks before our
  handler ran. Fixed by importing only the `Modal` class (`bootstrap/js/dist/modal`).

Then discovered the following issue, where navigation back to mybookings from reservation flow adding my bookings under checkout reservation flow.
- **Bug 2 — Reservation-flow content visible after navigation:** Three compounding issues left
  `<app-reservation-flow>` as an orphaned DOM node after routing away:
    1. `ngAfterContentChecked` was calling `detectChanges()` re-entrantly, interfering with Angular's CD
  cycle during navigation.
    2. `changeDetectorRef.detach()` in `ngOnDestroy` and a direct signal read
  (`stepperService.currentStepIndex()`) in the template disrupted Angular 19's view teardown sequence.
    3. Angular's `nativeRemoveNode` silently skipped the host element removal (no error thrown).
  Workaround: explicitly call `elementRef.nativeElement.remove()` in `ngOnDestroy`, making Angular's own
  attempt a safe no-op.

- Additional fix: `BreadcrumbComponent` was leaking a `router.events` subscription (no `ngOnDestroy`).
  Fixed with `takeUntilDestroyed`.