### PR TITLE
fix(booking-confirmation): remove duplicate loading spinner

### DIFF
--- a/src/app/booking-confirmation/booking-confirmation.component.html
+++ b/src/app/booking-confirmation/booking-confirmation.component.html
@@ -7,14 +7,6 @@
       
       <h2 class="fw-bold mb-4 text-primary">Checkout</h2>
 
-      <!-- Loading State -->
-      <div *ngIf="loading" class="text-center py-5">
-        <div class="spinner-border text-primary" role="status">
-          <span class="visually-hidden">Loading...</span>
-        </div>
-        <p class="mt-3">Loading booking details...</p>
-      </div>
-
       <!-- Error State -->
       <div *ngIf="!loading && error" class="alert alert-danger" role="alert">
         <i class="fa-solid fa-exclamation-triangle me-2"></i>


### PR DESCRIPTION
### Ticket:
https://github.com/bcgov/reserve-rec-public/issues/493

### Description:
- Removes local `spinner-border` block from booking-confirmation page
- Global loading overlay (via `LoadingService`) already handles the loading state, causing two spinners
  to show simultaneously
- Mirrors the same fix applied to my-bookings in #586
