### PR TITLE
fix(my-bookings): check if booking is pending before adding to active bookings

### DIFF
--- a/src/app/my-bookings/my-bookings.component.ts
+++ b/src/app/my-bookings/my-bookings.component.ts
@@ -104,8 +104,8 @@ export class MyBookingsComponent implements OnInit {
       const rangeEnd = DateTime.fromISO(item.endDate).endOf('day');
       const isCancelled = item.status === 'cancelled' || item.bookingStatus === 'cancelled';
       const hasEnded = this.today > rangeEnd;
+      const isPending = item.isPending === 'PENDING';
 
-      
       // Get the display name of the activity type from constants
       const activityType = Constants.activityTypes?.[item.activityType]?.display || BookingUtils.getActivityType(item);
 
@@ -129,7 +129,7 @@ export class MyBookingsComponent implements OnInit {
       // 4. Other - catch-all for debugging
       if (isCancelled) {
         this.cancelledBookings.push(booking);
-      } else if (!hasEnded) {
+      } else if (!hasEnded && !isPending) {
         this.activeBookings.push(booking);
       } else if (hasEnded) {
         this.pastBookings.push(booking);


### PR DESCRIPTION
… bookings #567

### Ticket:

[567](https://github.com/bcgov/reserve-rec-public/issues/567)

### Description:
- When a user clicks "Book day-use pass" on the facilities page, that booking is set to active.
In DynamoDB that maps to status: in progress. The booking is also assigned an isPending value of PENDING.
- If a booking is both Active and PENDING, the booking should not show up in the My Bookings - Active Bookings list.
