### PR TITLE
fix(facility): set disablePast to true on date input for bookings

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@aws-sdk/client-secrets-manager": "^3.921.0",
     "@aws-sdk/client-ssm": "^3.921.0",
     "@digitalspace/bcparks-bootstrap-theme": "^1.4.6",
-    "@digitalspace/ngds-forms": "^0.0.131",
+    "@digitalspace/ngds-forms": "^0.0.132",
     "@maplibre/ngx-maplibre-gl": "^19.0.0",
     "@popperjs/core": "^2.11.8",
     "@types/bootstrap": "^5.2.10",

--- a/src/app/facility-details/facility-details.component.html
+++ b/src/app/facility-details/facility-details.component.html
@@ -130,6 +130,7 @@
 					<div class="col-md-6">
 							<ngds-date-input
 								[class]="'text-white rounded-1'"
+								[disablePast]="true"
 								[control]="this.form.get('selectedDate')"
 								[label]="'Day of visit'"
 								[placeholder]="loadingDates ? 'Loading...' : 'Select a date'"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2371,10 +2371,10 @@
     bootstrap "^5.3.3"
     jquery "^3.6.0"
 
-"@digitalspace/ngds-forms@^0.0.131":
-  version "0.0.131"
-  resolved "https://registry.yarnpkg.com/@digitalspace/ngds-forms/-/ngds-forms-0.0.131.tgz#c1f07e5574125cb5de0e5e66a81d182a2189ea9c"
-  integrity sha512-wjbV9f9VgBUSmQR5vVwAMShW4+/DKzEWJeMrf3x38JRE+t7p6hTX5lJGwsCVkXKkaltJlc2npNxmB1qBjhC6EQ==
+"@digitalspace/ngds-forms@^0.0.132":
+  version "0.0.132"
+  resolved "https://registry.yarnpkg.com/@digitalspace/ngds-forms/-/ngds-forms-0.0.132.tgz#8ff9a9eba39fdbb2d301d93a20d43086cb6d5161"
+  integrity sha512-21UURAnlRRJWLE6AoXNE4Pb4CsFbaFBsXxcvklMXgQWFbBoXmlcJuAPtt26PyVgorl7zVxL4BeHvdEPgTro7sQ==
   dependencies:
     tslib "^2.3.0"
 


### PR DESCRIPTION
### Ticket:
https://github.com/bcgov/reserve-rec-public/issues/638


### Description:
On the public side we want to disable past year because users are only allowed to book future dates, so showing past dates is not good UI. the change only needs to happen on public side. so we can use this option to disable.

The change in ngds-forms was done here https://github.com/digitalspace/ngds-toolkit/pull/44 to allow new option `disablePast`