### PR TITLE
feat(login): sign up and log in with email instead of username

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -33,9 +33,9 @@
       </button>
       
       <ng-container *ngIf="authKey">
-        <amplify-authenticator 
-          [loginMechanisms]="['username']"
-          [signUpAttributes]="['email', 'given_name', 'family_name']"
+        <amplify-authenticator
+          [loginMechanisms]="['email']"
+          [signUpAttributes]="['given_name', 'family_name']"
           [initialState]="initialState">
         <ng-template amplifySlot="sign-up-form-fields">
 


### PR DESCRIPTION
### Ticket:
#561

### Description:
- Amplify Authenticator `loginMechanisms` username → email; drop redundant email signUp attribute.
- Pairs with bcgov/reserve-rec-api#438 (public pool: email sign-in).