### PR TITLE
fix(waiting-room): send unauthenticated users to login when a queue i…

### DIFF
--- a/src/app/guards/waiting-room.guard.spec.ts
+++ b/src/app/guards/waiting-room.guard.spec.ts
@@ -1,0 +1,78 @@
+import { TestBed } from '@angular/core/testing';
+import { Router, RouterStateSnapshot, ActivatedRouteSnapshot } from '@angular/router';
+
+import { WaitingRoomGuard } from './waiting-room.guard';
+import { AuthService } from '../services/auth.service';
+import { CartService } from '../services/cart.service';
+import { WaitingRoomService } from '../services/waiting-room.service';
+
+describe('WaitingRoomGuard', () => {
+  let guard: WaitingRoomGuard;
+  let authServiceSpy: jasmine.SpyObj<AuthService>;
+  let routerSpy: jasmine.SpyObj<Router>;
+  let waitingRoomServiceSpy: jasmine.SpyObj<WaitingRoomService>;
+  let cartServiceSpy: { items: jasmine.Spy };
+  let redirectSpy: jasmine.Spy;
+
+  const route = {} as ActivatedRouteSnapshot;
+  const state = { url: '/checkout' } as RouterStateSnapshot;
+
+  beforeEach(() => {
+    authServiceSpy = jasmine.createSpyObj('AuthService', ['getCurrentUser']);
+    routerSpy = jasmine.createSpyObj('Router', ['navigate']);
+    waitingRoomServiceSpy = jasmine.createSpyObj('WaitingRoomService',
+      ['hasValidAdmission', 'buildWaitingRoomUrl'],
+      { mode2Active: () => true });
+    cartServiceSpy = { items: jasmine.createSpy('items').and.returnValue([]) };
+
+    // Mode 2 gate is checked first in the guard, so drive tests through it —
+    // it exercises the same isAuthenticatedOrRedirected() branch as Mode 1 without needing
+    // cart fixtures.
+    waitingRoomServiceSpy.hasValidAdmission.and.returnValue(false);
+    waitingRoomServiceSpy.buildWaitingRoomUrl.and.returnValue('/waitingroom.html?collectionId=MODE2');
+
+    sessionStorage.removeItem('wr_bypass_guard');
+    sessionStorage.removeItem('returnUrl');
+
+    TestBed.configureTestingModule({
+      providers: [
+        WaitingRoomGuard,
+        { provide: AuthService, useValue: authServiceSpy },
+        { provide: Router, useValue: routerSpy },
+        { provide: CartService, useValue: cartServiceSpy },
+        { provide: WaitingRoomService, useValue: waitingRoomServiceSpy },
+      ],
+    });
+
+    guard = TestBed.inject(WaitingRoomGuard);
+
+    // window.location.href is a non-configurable property in real Chrome —
+    // it can't be spied on or swapped out, and assigning it for real would
+    // navigate the test runner away from the test page. The guard's redirect
+    // call is isolated behind the private redirectTo() method for exactly
+    // this reason; spy on that instead of touching window.location.
+    redirectSpy = spyOn<any>(guard, 'redirectTo').and.stub();
+  });
+
+  it('unauthenticated: returns false, stashes returnUrl, navigates to /login', () => {
+    authServiceSpy.getCurrentUser.and.returnValue(null);
+
+    const result = guard.canActivate(route, state);
+
+    expect(result).toBeFalse();
+    expect(sessionStorage.getItem('returnUrl')).toBe('/checkout');
+    expect(routerSpy.navigate).toHaveBeenCalledWith(['/login'], { queryParams: { reason: 'waiting-room' } });
+    expect(redirectSpy).not.toHaveBeenCalled();
+  });
+
+  it('authenticated: falls through to the waiting-room redirect', () => {
+    authServiceSpy.getCurrentUser.and.returnValue({ username: 'test-user' });
+
+    const result = guard.canActivate(route, state);
+
+    expect(result).toBeFalse();
+    expect(routerSpy.navigate).not.toHaveBeenCalled();
+    expect(waitingRoomServiceSpy.buildWaitingRoomUrl).toHaveBeenCalled();
+    expect(redirectSpy).toHaveBeenCalledWith('/waitingroom.html?collectionId=MODE2');
+  });
+});

--- a/src/app/guards/waiting-room.guard.ts
+++ b/src/app/guards/waiting-room.guard.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
-import { ActivatedRouteSnapshot, CanActivate, RouterStateSnapshot } from '@angular/router';
+import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
+import { AuthService } from '../services/auth.service';
 import { CartService } from '../services/cart.service';
 import { WaitingRoomService } from '../services/waiting-room.service';
 
@@ -8,7 +9,9 @@ const MODE2_FACILITY_KEY = 'MODE2#global#1';
 @Injectable({ providedIn: 'root' })
 export class WaitingRoomGuard implements CanActivate {
   constructor(
+    private authService: AuthService,
     private cartService: CartService,
+    private router: Router,
     private waitingRoomService: WaitingRoomService
   ) {}
 
@@ -21,6 +24,12 @@ export class WaitingRoomGuard implements CanActivate {
       if (sessionStorage.getItem('wr_bypass_guard') === '1') {
         sessionStorage.removeItem('wr_bypass_guard');
         return true;
+      }
+      // The waiting room requires a signed-in user. Send unauthenticated users to
+      // login (with a reason) instead of silently bouncing them off the standalone
+      // waiting room page back to the landing page.
+      if (!this.requireLogin(state)) {
+        return false;
       }
       const today = new Date().toISOString().slice(0, 10);
       window.location.href = this.waitingRoomService.buildWaitingRoomUrl(
@@ -49,6 +58,10 @@ export class WaitingRoomGuard implements CanActivate {
       return true;
     }
 
+    if (!this.requireLogin(state)) {
+      return false;
+    }
+
     window.location.href = this.waitingRoomService.buildWaitingRoomUrl(
       waitingRoomItem.collectionId,
       waitingRoomItem.activityType,
@@ -56,6 +69,20 @@ export class WaitingRoomGuard implements CanActivate {
       waitingRoomItem.startDate,
       '/checkout'
     );
+    return false;
+  }
+
+  /**
+   * Ensures a user is signed in. Returns true when authenticated. When not,
+   * stashes the return URL, routes to login with a waiting-room reason, and
+   * returns false so the caller can abort.
+   */
+  private requireLogin(state: RouterStateSnapshot): boolean {
+    if (this.authService.getCurrentUser()) {
+      return true;
+    }
+    sessionStorage.setItem('returnUrl', state.url);
+    this.router.navigate(['/login'], { queryParams: { reason: 'waiting-room' } });
     return false;
   }
 }

--- a/src/app/guards/waiting-room.guard.ts
+++ b/src/app/guards/waiting-room.guard.ts
@@ -28,13 +28,13 @@ export class WaitingRoomGuard implements CanActivate {
       // The waiting room requires a signed-in user. Send unauthenticated users to
       // login (with a reason) instead of silently bouncing them off the standalone
       // waiting room page back to the landing page.
-      if (!this.requireLogin(state)) {
+      if (!this.isAuthenticatedOrRedirected(state)) {
         return false;
       }
       const today = new Date().toISOString().slice(0, 10);
-      window.location.href = this.waitingRoomService.buildWaitingRoomUrl(
+      this.redirectTo(this.waitingRoomService.buildWaitingRoomUrl(
         'MODE2', 'global', '1', today, state.url
-      );
+      ));
       return false;
     }
 
@@ -58,18 +58,22 @@ export class WaitingRoomGuard implements CanActivate {
       return true;
     }
 
-    if (!this.requireLogin(state)) {
+    if (!this.isAuthenticatedOrRedirected(state)) {
       return false;
     }
 
-    window.location.href = this.waitingRoomService.buildWaitingRoomUrl(
+    this.redirectTo(this.waitingRoomService.buildWaitingRoomUrl(
       waitingRoomItem.collectionId,
       waitingRoomItem.activityType,
       waitingRoomItem.activityId,
       waitingRoomItem.startDate,
       '/checkout'
-    );
+    ));
     return false;
+  }
+
+  private redirectTo(url: string): void {
+    window.location.href = url;
   }
 
   /**
@@ -77,7 +81,7 @@ export class WaitingRoomGuard implements CanActivate {
    * stashes the return URL, routes to login with a waiting-room reason, and
    * returns false so the caller can abort.
    */
-  private requireLogin(state: RouterStateSnapshot): boolean {
+  private isAuthenticatedOrRedirected(state: RouterStateSnapshot): boolean {
     if (this.authService.getCurrentUser()) {
       return true;
     }

--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -5,6 +5,11 @@
     @if (!showAmplifyAuth) {
       <div class="login-selection-container text-center py-5">
         <div class="login-card">
+          @if (loginReason === 'waiting-room') {
+            <div class="alert alert-info text-start" role="alert">
+              Please sign in to join the waiting room. You'll continue automatically once you're logged in.
+            </div>
+          }
           <h1 class="mb-4 text-start">Log in</h1>
           <div class="d-flex flex-column align-items-center">
             <button

--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -4,6 +4,7 @@ import { LoginComponent } from './login.component';
 import { ConfigService } from '../services/config.service';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideRouter } from '@angular/router';
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -12,7 +13,7 @@ describe('LoginComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [LoginComponent],
-      providers: [ConfigService, provideHttpClient(), provideHttpClientTesting()]
+      providers: [ConfigService, provideHttpClient(), provideHttpClientTesting(), provideRouter([])]
     })
       .compileComponents();
 

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -9,7 +9,7 @@ import {
   confirmResetPassword,
 } from 'aws-amplify/auth';
 
-import { Router } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 
 
 @Component({
@@ -23,6 +23,8 @@ export class LoginComponent implements OnInit{
   showAmplifyAuth = false;
   authKey = Date.now();
   initialState: 'signIn' | 'signUp' = 'signIn';
+
+  loginReason: string | null = null;
 
   // Amplify surfaces the raw Cognito error in the authenticator's alert, which
   // leaked infrastructure detail to end users — e.g. "User pool client
@@ -62,12 +64,15 @@ export class LoginComponent implements OnInit{
 
   constructor(
     private authService: AuthService,
+    private route: ActivatedRoute,
     private router: Router
   ) {}
   currentDate = '';
   ngOnInit() {
     // Force authenticator reset by updating key
-    this.authKey = Date.now();    // If user is already authenticated, redirect to home
+    this.authKey = Date.now();
+    this.loginReason = this.route.snapshot.queryParamMap.get('reason');
+    // If user is already authenticated, redirect to home
     if (this.authService.user()) {
       this.router.navigate(['/']);
       return;

--- a/src/waitingroom.js
+++ b/src/waitingroom.js
@@ -329,8 +329,11 @@
   // The Angular SPA handles Cognito login. Store the intended URL so it can
   // redirect back after authentication.
   function redirectToLogin() {
-    sessionStorage.setItem('wr_return_url', window.location.href);
-    window.location.href = '/';
+    // Preserve the intended return URL and send the user to the login page.
+    // The SPA guard normally routes here already; this is the fallback for
+    // direct hits on the standalone waiting room page without a valid token.
+    sessionStorage.setItem('returnUrl', getReturnUrl());
+    window.location.href = '/login?reason=waiting-room';
   }
 
   // ── Init ──────────────────────────────────────────────────────────────────

--- a/src/waitingroom.js
+++ b/src/waitingroom.js
@@ -332,7 +332,8 @@
     // Preserve the intended return URL and send the user to the login page.
     // The SPA guard normally routes here already; this is the fallback for
     // direct hits on the standalone waiting room page without a valid token.
-    sessionStorage.setItem('returnUrl', getReturnUrl());
+    var p = new URLSearchParams(window.location.search);
+    sessionStorage.setItem('returnUrl', p.get('returnUrl') || window.location.href);
     window.location.href = '/login?reason=waiting-room';
   }
 


### PR DESCRIPTION
### Ticket:
https://github.com/bcgov/reserve-rec-public/issues/516

### Description:
When a Mode 2 (site-wide) or Mode 1 (per-facility) waiting room was enabled, picking a park redirected unauthenticated users off the standalone waiting room page back to the landing page with no message or error.

The waiting room requires a signed-in user, so the guard now routes unauthenticated users to /login?reason=waiting-room, stashing the return URL so they continue to the queue automatically after signing in. The login page shows an explanatory banner. Login is only forced when a queue is active; otherwise users reach the facility page as before and sign in at the booking form.  

The standalone waitingroom.js fallback now redirects to /login (was /) for direct hits without a valid token.

fixed Flow:
- Not signed in + pick park → sent to login page (not silent bounce to home), with message "Sign in to
  join the waiting room."
- After sign in → automatically continue to waiting room, no restart.
- Already signed in → straight to waiting room as before. No change.