### PR TITLE
revert: email login (pool still username-based) (#561)

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -33,9 +33,9 @@
       </button>
       
       <ng-container *ngIf="authKey">
-        <amplify-authenticator
-          [loginMechanisms]="['email']"
-          [signUpAttributes]="['given_name', 'family_name']"
+        <amplify-authenticator 
+          [loginMechanisms]="['username']"
+          [signUpAttributes]="['email', 'given_name', 'family_name']"
           [initialState]="initialState">
         <ng-template amplifySlot="sign-up-form-fields">
 


### PR DESCRIPTION
### Ticket:
#561

### Description:
- Reverts #625. Its pool-side companion (reserve-rec-api#438) can't deploy (Cognito rejects the `UsernameAttributes` change), so the pool stays username-based; the email `loginMechanisms` change would break signup/login. Reverting to keep FE + pool consistent.
- #561 re-scoped for a new-pool approach.

Ref #561