### PR TITLE
fix(account): use shared breadcrumb on account settings (#630)

### DIFF
--- a/src/app/account-details/account-details.component.html
+++ b/src/app/account-details/account-details.component.html
@@ -1,8 +1,6 @@
 <div class="container my-4 account-settings">
 
-  <nav class="small mb-2" aria-label="breadcrumb">
-    <a routerLink="/">Home</a> <span class="text-muted">&rsaquo; Account settings</span>
-  </nav>
+  <app-breadcrumb></app-breadcrumb>
   <h1 class="h3 fw-bold mb-4">Account settings</h1>
 
   <!-- Email not verified -->

--- a/src/app/account-details/account-details.component.ts
+++ b/src/app/account-details/account-details.component.ts
@@ -2,17 +2,17 @@ import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../services/auth.service';
 import { ToastService, ToastTypes } from '../services/toast.service';
 
-import { RouterLink } from '@angular/router';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { NgdsFormsModule } from '@digitalspace/ngds-forms';
 import { PROVINCES_STATES } from '../data/provinces-states.data';
+import { BreadcrumbComponent } from '../shared/breadcrumb/breadcrumb.component';
 
 type EditSection = 'contact' | 'vehicle' | null;
 
 @Component({
   selector: 'app-account-details',
   standalone: true,
-  imports: [RouterLink, ReactiveFormsModule, NgdsFormsModule],
+  imports: [BreadcrumbComponent, ReactiveFormsModule, NgdsFormsModule],
   templateUrl: './account-details.component.html',
   styleUrl: './account-details.component.scss'
 })

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -38,7 +38,8 @@ export const routes: Routes = [
     path: 'account-details',
     canActivate: [UserGuard],
     loadComponent: () => import('./account-details/account-details.component')
-      .then(mod => mod.AccountDetailsComponent)
+      .then(mod => mod.AccountDetailsComponent),
+    data: { breadcrumb: 'Account settings' }
   },
   // {
   //   path: 'activity/:collectionId/:activityType/:identifier',

--- a/src/app/shared/breadcrumb/breadcrumb.component.spec.ts
+++ b/src/app/shared/breadcrumb/breadcrumb.component.spec.ts
@@ -1,0 +1,68 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router, provideRouter } from '@angular/router';
+import { Component } from '@angular/core';
+
+import { BreadcrumbComponent } from './breadcrumb.component';
+
+@Component({ template: '', standalone: true })
+class StubPageComponent {}
+
+describe('BreadcrumbComponent', () => {
+  let fixture: ComponentFixture<BreadcrumbComponent>;
+  let router: Router;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [BreadcrumbComponent],
+      providers: [
+        provideRouter([
+          { path: '', component: StubPageComponent },
+          {
+            path: 'account-details',
+            component: StubPageComponent,
+            data: { breadcrumb: 'Account settings' }
+          },
+        ]),
+      ]
+    }).compileComponents();
+
+    router = TestBed.inject(Router);
+    fixture = TestBed.createComponent(BreadcrumbComponent);
+  });
+
+  it('renders nothing at the root, where Home is the only crumb', async () => {
+    await router.navigateByUrl('/');
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement).querySelectorAll('.breadcrumb-item').length).toBe(0);
+  });
+
+  describe('on a child route', () => {
+    beforeEach(async () => {
+      await router.navigateByUrl('/account-details');
+      fixture.detectChanges();
+    });
+
+    it('renders Home and the route breadcrumb label', () => {
+      const labels = [...(fixture.nativeElement as HTMLElement).querySelectorAll('.breadcrumb-item')]
+        .map(el => (el.textContent ?? '').trim());
+
+      expect(labels).toEqual(['Home', 'Account settings']);
+    });
+
+    // #630: the separator must be spaced away from the labels. The previous
+    // hand-rolled breadcrumb relied on a whitespace text node between elements,
+    // which Angular strips (preserveWhitespaces defaults to false).
+    it('renders a separator that carries its own horizontal padding', () => {
+      const separator = (fixture.nativeElement as HTMLElement).querySelector('.breadcrumb-separator');
+
+      expect(separator).withContext('separator element is present').not.toBeNull();
+      expect(separator!.querySelector('i.fa-chevron-right'))
+        .withContext('separator uses the chevron icon').not.toBeNull();
+
+      const padding = getComputedStyle(separator as Element);
+      expect(parseFloat(padding.paddingLeft)).toBeGreaterThan(0);
+      expect(parseFloat(padding.paddingRight)).toBeGreaterThan(0);
+    });
+  });
+});


### PR DESCRIPTION
### Ticket:
#630

### Description:
Account settings hand-rolled its breadcrumb and relied on a whitespace text node for the gap before `›`. Angular strips that (`preserveWhitespaces` is false), so it rendered `Home› Account settings`.

Swapped in the shared `<app-breadcrumb>`, which spaces the chevron via CSS and matches the other six pages already using it. Adds a spec for that component, which had none.

Note: breadcrumb spacing on this page changes from `small mb-2` to the shared `pt-4 mb-5`.

Ref #630