### PR TITLE
fix(account): tear down edit form after saving account details (#63)

### DIFF
--- a/src/app/account-details/account-details.component.spec.ts
+++ b/src/app/account-details/account-details.component.spec.ts
@@ -1,0 +1,142 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { AccountDetailsComponent } from './account-details.component';
+import { AuthService } from '../services/auth.service';
+import { ToastService } from '../services/toast.service';
+import { provideRouter } from '@angular/router';
+
+const MOCK_USER = {
+  given_name: 'Test',
+  family_name: 'User',
+  email: 'test@test.com',
+  'custom:streetAddress': '123 Main St',
+  'custom:unitNumber': '4',
+  'custom:city': 'Vancouver',
+  'custom:province': 'British Columbia',
+  'custom:postalCode': 'V9C 4G1',
+  'custom:country': 'Canada',
+  'custom:mobilePhone': '6786786761',
+  'custom:secondaryNumber': '8989090981',
+  'custom:licensePlate': 'ABC123',
+  'custom:vehicleRegLocale': 'Yukon',
+};
+
+describe('AccountDetailsComponent', () => {
+  let component: AccountDetailsComponent;
+  let fixture: ComponentFixture<AccountDetailsComponent>;
+  let authService: jasmine.SpyObj<AuthService>;
+
+  beforeEach(async () => {
+    authService = jasmine.createSpyObj('AuthService',
+      ['getCurrentUser', 'isBcscUser', 'checkEmailVerification', 'updateUserProfile', 'logout', 'handleResendAttributeCodeToEmail']);
+    authService.getCurrentUser.and.returnValue(MOCK_USER);
+    authService.isBcscUser.and.returnValue(false);
+    authService.checkEmailVerification.and.resolveTo(true);
+    authService.updateUserProfile.and.resolveTo();
+
+    await TestBed.configureTestingModule({
+      imports: [AccountDetailsComponent],
+      providers: [
+        provideRouter([]),
+        { provide: AuthService, useValue: authService },
+        { provide: ToastService, useValue: jasmine.createSpyObj('ToastService', ['addMessage']) },
+      ]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(AccountDetailsComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  function text(): string {
+    return (fixture.nativeElement as HTMLElement).textContent ?? '';
+  }
+
+  function formCount(): number {
+    return (fixture.nativeElement as HTMLElement).querySelectorAll('form').length;
+  }
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  // QA send-back #63: read-only details and the edit form were both on the page
+  // at once, with the Edit button still showing. The two blocks must be mutually
+  // exclusive for every value of `editing`.
+  describe('edit sections are mutually exclusive', () => {
+    it('shows read-only details and no form when not editing', () => {
+      expect(component.editing).toBeNull();
+      expect(text()).toContain('Phone numbers');
+      expect(formCount()).toBe(0);
+    });
+
+    it('hides the read-only contact details while editing contact', () => {
+      component.startEdit('contact');
+      fixture.detectChanges();
+
+      expect(text()).not.toContain('Phone numbers');
+      expect(formCount()).toBe(1);
+    });
+
+    it('hides the read-only vehicle details while editing vehicle', () => {
+      component.startEdit('vehicle');
+      fixture.detectChanges();
+
+      expect(text()).not.toContain('ABC123, Yukon');
+      expect(formCount()).toBe(1);
+    });
+
+    it('restores the read-only view and removes the form after a successful save', async () => {
+      component.startEdit('contact');
+      fixture.detectChanges();
+      expect(formCount()).toBe(1);
+
+      await component.saveContact();
+      fixture.detectChanges();
+
+      expect(component.editing).toBeNull();
+      expect(formCount()).toBe(0);
+      expect(text()).toContain('Phone numbers');
+    });
+
+    it('keeps the form open when the save fails', async () => {
+      authService.updateUserProfile.and.rejectWith(new Error('nope'));
+      component.startEdit('contact');
+      fixture.detectChanges();
+
+      await component.saveContact();
+      fixture.detectChanges();
+
+      expect(component.editing).toBe('contact');
+      expect(formCount()).toBe(1);
+    });
+  });
+
+  it('only allows one card to be edited at a time', () => {
+    component.startEdit('contact');
+    component.startEdit('vehicle');
+
+    expect(component.editing).toBe('contact');
+  });
+
+  // Drives the component the way a browser does — a real click on Save, with
+  // zone-driven change detection rather than a manual detectChanges().
+  it('removes the form after clicking Save, without a manual detectChanges', async () => {
+    fixture.autoDetectChanges(true);
+
+    const el = fixture.nativeElement as HTMLElement;
+    (el.querySelector('.card-header button') as HTMLButtonElement).click();
+    await fixture.whenStable();
+    expect(el.querySelectorAll('form').length).toBe(1);
+
+    const save = Array.from(el.querySelectorAll('form button'))
+      .find(b => (b.textContent ?? '').trim() === 'Save') as HTMLButtonElement;
+    save.click();
+    await fixture.whenStable();
+
+    expect(component.editing).toBeNull();
+    expect(el.querySelectorAll('form').length).toBe(0);
+    expect(el.textContent).toContain('Phone numbers');
+  });
+});

--- a/src/app/account-details/account-details.component.ts
+++ b/src/app/account-details/account-details.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { AuthService } from '../services/auth.service';
 import { ToastService, ToastTypes } from '../services/toast.service';
 
@@ -42,7 +42,11 @@ export class AccountDetailsComponent implements OnInit {
     vehicleRegLocale: new FormControl(''),
   });
 
-  constructor(private authService: AuthService, private toastService: ToastService) {}
+  constructor(
+    private authService: AuthService,
+    private toastService: ToastService,
+    private cd: ChangeDetectorRef,
+  ) {}
 
   async ngOnInit(): Promise<void> {
     this.emailVerified = await this.authService.checkEmailVerification();
@@ -124,6 +128,12 @@ export class AccountDetailsComponent implements OnInit {
       this.toastService.addMessage('We could not save your changes. Please try again.', 'Error', ToastTypes.ERROR);
     } finally {
       this.saving = false;
+      // `editing` and `saving` are plain properties mutated in a post-await
+      // continuation. Without this the edit form's view is not torn down, so the
+      // form stays on screen alongside the restored read-only details
+      // (QA send-back on #63). Verified: forcing detection here is what the
+      // manual ng.applyChanges() reproduction needed to clear it.
+      this.cd.detectChanges();
     }
   }
 


### PR DESCRIPTION
### Ticket:
#63

### Description:

QA send-back point 3: after saving, the edit form stayed on screen next to the restored read-only details ("duplicate sections").

Reproduced live against the dev pool. The component state was correct — `editing === null`, one component instance, both views correctly positioned against their own `@if` anchors — but the edit form's view was never destroyed. Entering edit mode tore down the read-only block fine; only the exit transition failed, and it still failed with the Cognito call, the `user` signal write and the toast all stubbed out. The one thing left was that `editing` is cleared in a post-`await` continuation. Forcing detection there clears it, which is what the manual `ng.applyChanges()` reproduction needed.

Also adds spec coverage for this component — the spec file was previously empty.

Two things reviewers should know:

- The new tests pass with **and** without the fix. This defect only appears under real zone-driven change detection in a browser, so `TestBed` can't catch it. They're coverage, not a regression guard for this bug.
- The root cause is uncharacterised. I can't explain why one `@if` re-evaluated while its sibling in the same pass did not. `detectChanges()` resolves it deterministically and was verified end to end, but this is a fix at the symptom.

`resendVerification()` and `ngOnInit()`'s `emailVerified` assignment mutate plain properties after an `await` in the same way and may be affected; left alone to keep this scoped to the QA defect.

Out of scope, split out separately: point 1 (designs) is #634; point 2 (email/password) is #643 and #644.

Ref #63