### PR TITLE
chore(codeowners): add @fergmac as a code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence,
 # they will be requested for review when someone opens a pull request.
-*       @marklise @meredithom @Christopher-walsh22 @davidclaveau
+*       @marklise @meredithom @Christopher-walsh22 @davidclaveau @fergmac


### PR DESCRIPTION
### Description:

Adds @fergmac to the default owner list so he is automatically requested for review on pull requests in this repo.

Applied identically across the seven team repos: reserve-rec-public, reserve-rec-admin, reserve-rec-api, parks-reso-public, parks-reso-admin, parks-reso-api and parks-data-register.

He already holds `admin` on all of them (inherited via team, not as a direct collaborator), so the entry takes effect immediately — CODEOWNERS silently ignores owners without write access, which is not a factor here.

Note this puts him on **every** PR in this repo, matching how the other four owners are configured.