### PR TITLE
fix(account): tear down the edit form when Cancel is clicked (#63)

### DIFF
--- a/src/app/account-details/account-details.component.spec.ts
+++ b/src/app/account-details/account-details.component.spec.ts
@@ -120,6 +120,31 @@ describe('AccountDetailsComponent', () => {
     expect(component.editing).toBe('contact');
   });
 
+  // Cancel is the same editing -> null transition as a successful save, and it
+  // needs the same explicit teardown. Both cards share cancelEdit().
+  ([['contact', 0], ['vehicle', 1]] as const).forEach(([section, editIndex]) => {
+    it(`removes the ${section} form after clicking Cancel, without a manual detectChanges`, async () => {
+      fixture.autoDetectChanges(true);
+      const el = fixture.nativeElement as HTMLElement;
+
+      const edit = [...el.querySelectorAll('button')]
+        .filter(b => (b.textContent ?? '').trim() === 'Edit')[editIndex] as HTMLButtonElement;
+      edit.click();
+      await fixture.whenStable();
+      expect(component.editing).toBe(section);
+      expect(el.querySelectorAll('form').length).toBe(1);
+
+      const cancel = Array.from(el.querySelectorAll('form button'))
+        .find(b => (b.textContent ?? '').trim() === 'Cancel') as HTMLButtonElement;
+      cancel.click();
+      await fixture.whenStable();
+
+      expect(component.editing).toBeNull();
+      expect(el.querySelectorAll('form').length).toBe(0);
+      expect(el.textContent).toContain('Phone numbers');
+    });
+  });
+
   // Drives the component the way a browser does — a real click on Save, with
   // zone-driven change detection rather than a manual detectChanges().
   it('removes the form after clicking Save, without a manual detectChanges', async () => {

--- a/src/app/account-details/account-details.component.ts
+++ b/src/app/account-details/account-details.component.ts
@@ -92,6 +92,9 @@ export class AccountDetailsComponent implements OnInit {
 
   cancelEdit(): void {
     this.editing = null;
+    // Same teardown problem as save(): clearing `editing` on its own leaves the
+    // edit form's view in the DOM alongside the restored read-only details.
+    this.cd.detectChanges();
   }
 
   async saveContact(): Promise<void> {


### PR DESCRIPTION
### Ticket:
#63

### Description:

Clicking **Cancel** left the edit form on screen beside the restored read-only details — the same defect #645 fixed for **Save**, on the exit path I missed. Both cards share `cancelEdit()`, so Contact and Vehicle were affected. Fix adds `this.cd.detectChanges()` after clearing `editing`. Confirmed in a browser against the dev pool.

Corrects #645's stated cause: it blamed a post-`await` continuation, but `cancelEdit()` is synchronous and fails identically. The real issue is that the `editing → null` exit transition doesn't tear down the view, however it's triggered.

The two added tests pass with and without the fix — this only reproduces in a real browser, so they document behaviour rather than guard it.

Ref #63