### PR TITLE
fix(account): align account settings page with the UI design guidelines (#634)

### DIFF
--- a/src/app/account-details/account-details.component.html
+++ b/src/app/account-details/account-details.component.html
@@ -29,11 +29,11 @@
     <div class="row g-4">
       <!-- Contact information -->
       <div class="col-lg-8">
-        <div class="card h-100" [class.opacity-50]="editing && editing !== 'contact'">
-          <div class="card-header bg-light d-flex justify-content-between align-items-center">
+        <div class="card h-100">
+          <div class="card-header d-flex justify-content-between align-items-center">
             <span class="fw-semibold">Contact information</span>
             @if (!isBcsc && editing !== 'contact') {
-              <button class="btn btn-outline-primary btn-sm"
+              <button class="btn btn-outline-primary"
               [disabled]="editing" (click)="startEdit('contact')">Edit</button>
             }
           </div>
@@ -41,11 +41,11 @@
             <!-- Read-only -->
             @if (editing !== 'contact') {
               <div class="mb-3">
-                <div class="fw-semibold">Name</div>
+                <div class="field-label">Name</div>
                 <div>{{ user.given_name }} {{ user.family_name }}</div>
               </div>
               <div class="mb-3">
-                <div class="fw-semibold">Home address</div>
+                <div class="field-label">Home address</div>
                 <div>{{ user['custom:streetAddress'] }}@if (user['custom:unitNumber']) {
                   <span>, {{ user['custom:unitNumber'] }}</span>
                 }</div>
@@ -55,7 +55,7 @@
                 <div>{{ user['custom:country'] }}</div>
               </div>
               <div>
-                <div class="fw-semibold">Phone numbers</div>
+                <div class="field-label">Phone numbers</div>
                 <div class="d-flex"><span class="text-muted phone-label">Mobile:</span><span>{{ user['custom:mobilePhone'] || '—' }}</span></div>
                 <div class="d-flex"><span class="text-muted phone-label">Alternate:</span><span>{{ user['custom:secondaryNumber'] || '—' }}</span></div>
               </div>
@@ -102,40 +102,40 @@
       </div>
       <!-- Account management -->
       <div class="col-lg-4">
-        <div class="card h-100" [class.opacity-50]="editing">
-          <div class="card-header bg-light"><span class="fw-semibold">Account management</span></div>
+        <div class="card h-100">
+          <div class="card-header"><span class="fw-semibold">Account management</span></div>
           <div class="card-body">
             <div class="mb-3">
-              <div class="fw-semibold">Email address</div>
+              <div class="field-label">Email address</div>
               <div>
                 {{ user.email }}
                 @if (emailVerified) {
-                  <span class="text-success small ms-1"><i class="fa-solid fa-circle-check"></i> Verified</span>
+                  <span class="status-verified ms-1"><i class="fa-solid fa-circle-check"></i> Verified</span>
                 }
                 @if (!emailVerified) {
-                  <span class="text-danger small ms-1"><i class="fa-solid fa-circle-xmark"></i> Not verified</span>
+                  <span class="status-unverified ms-1"><i class="fa-solid fa-circle-xmark"></i> Not verified</span>
                 }
               </div>
               <!-- Email change is handled in a follow-up ticket -->
-              <button class="btn btn-outline-primary btn-sm mt-2" disabled title="Coming soon">Change email address</button>
+              <button class="btn btn-outline-primary mt-2" disabled title="Coming soon">Change email address</button>
             </div>
             <hr>
               <div>
-                <div class="fw-semibold">Password</div>
-                <div class="text-muted small">Updated {{ user['custom:pwUpdate'] || 'previously' }}</div>
+                <div class="field-label">Password</div>
+                <div class="field-value">Updated {{ user['custom:pwUpdate'] || 'previously' }}</div>
                 <!-- Password change is handled in a follow-up ticket -->
-                <button class="btn btn-outline-primary btn-sm mt-2" disabled title="Coming soon">Change password</button>
+                <button class="btn btn-outline-primary mt-2" disabled title="Coming soon">Change password</button>
               </div>
             </div>
           </div>
         </div>
         <!-- Vehicle information -->
         <div class="col-lg-8">
-          <div class="card" [class.opacity-50]="editing && editing !== 'vehicle'">
-            <div class="card-header bg-light d-flex justify-content-between align-items-center">
+          <div class="card">
+            <div class="card-header d-flex justify-content-between align-items-center">
               <span class="fw-semibold">Vehicle information <span class="text-muted fw-normal">(optional)</span></span>
               @if (editing !== 'vehicle') {
-                <button class="btn btn-outline-primary btn-sm"
+                <button class="btn btn-outline-primary"
                 [disabled]="editing" (click)="startEdit('vehicle')">Edit</button>
               }
             </div>

--- a/src/app/account-details/account-details.component.scss
+++ b/src/app/account-details/account-details.component.scss
@@ -36,12 +36,93 @@
     padding-bottom: 5%; 
   }
 
+// Values below come from the ready-for-development Figma frame for this page
+// (PRDT - Public, "Account – Account settings – APRIL", desktop). Ref #634.
 .account-settings {
   .phone-label {
     width: 90px;
     flex: 0 0 90px;
   }
+
+  // #634 item 1: page heading is the primary dark blue, not the default body colour.
+  h1 {
+    color: var(--rr-primary-dark);
+  }
+
+  // #634 item 2: section headers use #F2F2F2 rather than Bootstrap's bg-light,
+  // with the title at 1rem/700. Mobile pads 16px all round; tablet and desktop
+  // widen the horizontal padding to 24px. Heading and button sizing are
+  // identical across all three breakpoints.
   .card-header {
-    font-size: 0.95rem;
+    background-color: #f2f2f2;
+    padding: 1rem;
+    font-size: 1rem;
+
+    .fw-semibold {
+      font-weight: 700;
+    }
+  }
+
+  @media (min-width: 576px) {
+    .card-header {
+      padding: 1rem 1.5rem;
+    }
+  }
+
+  // #634 item 3: buttons are 48px tall with a 4px radius and 12px/16px padding.
+  // Scoped to this page so buttons elsewhere are untouched.
+  .btn {
+    --bs-btn-border-radius: 4px;
+    min-height: 48px;
+    padding: 0.75rem 1rem;
+    font-size: 1rem;
+    font-weight: 700;
+  }
+
+  .btn-outline-primary {
+    --bs-btn-color: var(--rr-primary-dark);
+    --bs-btn-border-color: var(--rr-primary-dark);
+    --bs-btn-bg: #fff;
+    --bs-btn-hover-bg: var(--rr-primary-dark);
+    --bs-btn-hover-border-color: var(--rr-primary-dark);
+  }
+
+  .btn-primary {
+    --bs-btn-bg: var(--rr-primary-dark);
+    --bs-btn-border-color: var(--rr-primary-dark);
+  }
+
+  // Link-style Cancel, and anything explicitly small, keep their own sizing
+  // rather than the 48px block treatment.
+  .btn-link,
+  .btn-sm {
+    min-height: auto;
+    padding: revert;
+    font-size: revert;
+  }
+
+  // #634 item 4: verified / not verified use the design's own green and red at
+  // body size, not Bootstrap's semantic colours at 0.875em.
+  .status-verified,
+  .status-unverified {
+    font-size: 1rem;
+  }
+
+  .status-verified {
+    color: #4f8747;
+  }
+
+  .status-unverified {
+    color: #d8292f;
+  }
+
+  // #634 item 5: 4px between a field label and its value; muted values at #656565.
+  .field-label {
+    font-weight: 700;
+    margin-bottom: 0.25rem;
+  }
+
+  .field-value {
+    color: #656565;
   }
 }

--- a/src/app/account-details/account-details.component.spec.ts
+++ b/src/app/account-details/account-details.component.spec.ts
@@ -113,6 +113,21 @@ describe('AccountDetailsComponent', () => {
     });
   });
 
+  // #634 item 6: while one section is being edited, the other sections should
+  // still look enabled — only their buttons are disabled.
+  it('does not dim the other cards while editing', () => {
+    component.startEdit('contact');
+    fixture.detectChanges();
+
+    const el = fixture.nativeElement as HTMLElement;
+    expect(el.querySelectorAll('.card.opacity-50').length).toBe(0);
+
+    const editButtons = [...el.querySelectorAll('button')]
+      .filter(b => (b.textContent ?? '').trim() === 'Edit') as HTMLButtonElement[];
+    expect(editButtons.length).toBeGreaterThan(0);
+    expect(editButtons.every(b => b.disabled)).toBeTrue();
+  });
+
   it('only allows one card to be edited at a time', () => {
     component.startEdit('contact');
     component.startEdit('vehicle');

--- a/src/app/account-details/account-details.component.spec.ts
+++ b/src/app/account-details/account-details.component.spec.ts
@@ -120,6 +120,31 @@ describe('AccountDetailsComponent', () => {
     expect(component.editing).toBe('contact');
   });
 
+  // Cancel is the same editing -> null transition as a successful save, and it
+  // needs the same explicit teardown. Both cards share cancelEdit().
+  ([['contact', 0], ['vehicle', 1]] as const).forEach(([section, editIndex]) => {
+    it(`removes the ${section} form after clicking Cancel, without a manual detectChanges`, async () => {
+      fixture.autoDetectChanges(true);
+      const el = fixture.nativeElement as HTMLElement;
+
+      const edit = [...el.querySelectorAll('button')]
+        .filter(b => (b.textContent ?? '').trim() === 'Edit')[editIndex] as HTMLButtonElement;
+      edit.click();
+      await fixture.whenStable();
+      expect(component.editing).toBe(section);
+      expect(el.querySelectorAll('form').length).toBe(1);
+
+      const cancel = Array.from(el.querySelectorAll('form button'))
+        .find(b => (b.textContent ?? '').trim() === 'Cancel') as HTMLButtonElement;
+      cancel.click();
+      await fixture.whenStable();
+
+      expect(component.editing).toBeNull();
+      expect(el.querySelectorAll('form').length).toBe(0);
+      expect(el.textContent).toContain('Phone numbers');
+    });
+  });
+
   // Drives the component the way a browser does — a real click on Save, with
   // zone-driven change detection rather than a manual detectChanges().
   it('removes the form after clicking Save, without a manual detectChanges', async () => {

--- a/src/app/account-details/account-details.component.ts
+++ b/src/app/account-details/account-details.component.ts
@@ -92,6 +92,9 @@ export class AccountDetailsComponent implements OnInit {
 
   cancelEdit(): void {
     this.editing = null;
+    // Same teardown problem as save(): clearing `editing` on its own leaves the
+    // edit form's view in the DOM alongside the restored read-only details.
+    this.cd.detectChanges();
   }
 
   async saveContact(): Promise<void> {


### PR DESCRIPTION
### Ticket:
#634

### Description:

All six reported items:

1. Heading uses `--rr-primary-dark` (#003366)
2. Section headers #F2F2F2, 16px padding (24px horizontal at ≥576px)
3. Buttons 48px, 4px radius, bold labels
4. Verified #4F8747 / Not verified #D8292F at 1rem
5. 4px label→value gap; muted values #656565
6. Removed the `opacity-50` dimming of inactive cards

Button sizing is scoped to `.account-settings`; `.btn-link` and `.btn-sm` opt out.

Stacked on #647; merge that first.

Ref #634