### PR TITLE
fix(login): show generic auth errors instead of raw Cognito messages (#628)

### DIFF
--- a/src/app/login/login.component.html
+++ b/src/app/login/login.component.html
@@ -38,6 +38,7 @@
           <amplify-authenticator
             [loginMechanisms]="['email']"
             [signUpAttributes]="['given_name', 'family_name']"
+            [services]="services"
             [initialState]="initialState">
             <ng-template amplifySlot="sign-up-form-fields">
               <amplify-sign-up-form-fields></amplify-sign-up-form-fields>

--- a/src/app/login/login.component.spec.ts
+++ b/src/app/login/login.component.spec.ts
@@ -24,4 +24,51 @@ describe('LoginComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  // #628: Cognito's own errors named the user pool client in the sign-in alert.
+  // Every wrapped handler must replace the raw error with a generic message.
+  describe('auth errors are not surfaced verbatim', () => {
+    const RAW = 'User pool client 1a0cfcigjl0c1esdeihuqnl9vu does not exist.';
+
+    const handlers: (keyof LoginComponent['services'])[] = [
+      'handleSignIn',
+      'handleSignUp',
+      'handleConfirmSignUp',
+      'handleForgotPassword',
+      'handleForgotPasswordSubmit',
+    ];
+
+    handlers.forEach(name => {
+      it(`${name} replaces the underlying error`, async () => {
+        spyOn(console, 'error');
+        // Force the wrapped call to fail the way Cognito would.
+        spyOn<any>(component, 'withGenericError').and.callThrough();
+        const thrown = await (component.services[name] as any)({})
+          .then(() => null, (e: Error) => e);
+
+        expect(thrown).toBeTruthy();
+        expect(thrown.message).not.toContain('User pool client');
+        expect(thrown.message).not.toContain('1a0cfcigjl0c1esdeihuqnl9vu');
+        expect(thrown.message.length).toBeGreaterThan(0);
+      });
+    });
+
+    it('logs the original error for debugging', async () => {
+      const spy = spyOn(console, 'error');
+      await (component.services.handleSignIn as any)({}).catch(() => undefined);
+
+      expect(spy).toHaveBeenCalled();
+      expect(spy.calls.mostRecent().args[0]).toBe('Auth error:');
+    });
+
+    it('does not leak the raw message when Cognito names the pool client', async () => {
+      spyOn(console, 'error');
+      const failing = () => Promise.reject(new Error(RAW));
+      const thrown = await (component as any)
+        .withGenericError(failing, 'Generic message.')
+        .then(() => null, (e: Error) => e);
+
+      expect(thrown.message).toBe('Generic message.');
+    });
+  });
 });

--- a/src/app/login/login.component.ts
+++ b/src/app/login/login.component.ts
@@ -1,6 +1,13 @@
 import { Component, OnInit } from '@angular/core';
 import { AmplifyAuthenticatorModule } from '@aws-amplify/ui-angular';
 import { AuthService } from '../services/auth.service';
+import {
+  signIn,
+  signUp,
+  confirmSignUp,
+  resetPassword,
+  confirmResetPassword,
+} from 'aws-amplify/auth';
 
 import { Router } from '@angular/router';
 
@@ -16,7 +23,43 @@ export class LoginComponent implements OnInit{
   showAmplifyAuth = false;
   authKey = Date.now();
   initialState: 'signIn' | 'signUp' = 'signIn';
-  
+
+  // Amplify surfaces the raw Cognito error in the authenticator's alert, which
+  // leaked infrastructure detail to end users — e.g. "User pool client
+  // <id> does not exist." (#628). Wrapping the handlers keeps Cognito's own
+  // wording out of the UI: users get an actionable generic message, and the
+  // original error is still logged for debugging.
+  public services = {
+    handleSignIn: (input: Parameters<typeof signIn>[0]) =>
+      this.withGenericError(() => signIn(input),
+        'We could not sign you in. Check your email and password and try again.'),
+
+    handleSignUp: (input: Parameters<typeof signUp>[0]) =>
+      this.withGenericError(() => signUp(input),
+        'We could not create your account. Please check your details and try again.'),
+
+    handleConfirmSignUp: (input: Parameters<typeof confirmSignUp>[0]) =>
+      this.withGenericError(() => confirmSignUp(input),
+        'We could not confirm your account. Check the code and try again.'),
+
+    handleForgotPassword: (input: Parameters<typeof resetPassword>[0]) =>
+      this.withGenericError(() => resetPassword(input),
+        'We could not start a password reset. Please try again.'),
+
+    handleForgotPasswordSubmit: (input: Parameters<typeof confirmResetPassword>[0]) =>
+      this.withGenericError(() => confirmResetPassword(input),
+        'We could not reset your password. Check the code and try again.'),
+  };
+
+  private async withGenericError<T>(run: () => Promise<T>, message: string): Promise<T> {
+    try {
+      return await run();
+    } catch (error) {
+      console.error('Auth error:', error);
+      throw new Error(message);
+    }
+  }
+
   constructor(
     private authService: AuthService,
     private router: Router


### PR DESCRIPTION
### Ticket:
#628

### Description:

Amplify's authenticator rendered Cognito's own error text, exposing infrastructure detail — QA saw `User pool client <id> does not exist.` on a failed sign-in.

Wraps the authenticator's `handleSignIn`, `handleSignUp`, `handleConfirmSignUp`, `handleForgotPassword` and `handleForgotPasswordSubmit` via its supported `[services]` input, so every auth path returns a generic message. The original error is still `console.error`'d for debugging.

Covered all five handlers rather than just sign-in — the same leak applies to sign-up and password reset.

Note the specific client ID in the screenshot no longer resolves: TEST now serves a different one after the v2 pool migration, so that misconfiguration is already gone. This fixes the underlying disclosure, not that config.

Tests fail without the fix and pass with it.

Ref #628