### PR TITLE
fix(account): force email wording on confirm sign-up screen

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable, signal } from '@angular/core';
 import { Amplify } from "aws-amplify";
 import { ConfigService } from './config.service';
-import { Hub } from 'aws-amplify/utils';
+import { Hub, I18n } from 'aws-amplify/utils';
 import { fetchAuthSession, signOut, signInWithRedirect, fetchUserAttributes, sendUserAttributeVerificationCode, updateUserAttributes } from 'aws-amplify/auth';
 import { LoggerService } from './logger.service';
 import { Router } from '@angular/router';
@@ -41,6 +41,19 @@ export class AuthService {
           },
         },
       }
+    });
+
+    // This app only ever verifies sign-up via email (autoVerify: email only in
+    // the Cognito pool). Amplify UI's confirm-sign-up screen falls back to SMS
+    // wording whenever Cognito's codeDeliveryDetails doesn't resolve to a known
+    // medium (e.g. the verification email failed to send), which wrongly tells
+    // users "We Texted You". Force it to the email wording so it never lies
+    // about how the code was (or should have been) delivered.
+    I18n.putVocabularies({
+      en: {
+        'We Texted You': 'We Emailed You',
+        'Your code is on the way. To log in, enter the code we texted to': 'Your code is on the way. To log in, enter the code we emailed to',
+      },
     });
 
     await this.listenToAuthEvents();


### PR DESCRIPTION
### Ticket:
https://github.com/bcgov/reserve-rec-public/issues/632

### Description:
#### What this fixes
 The misleading "We Texted You" wording on the confirm-sign-up screen

#### What it doesn't fix
Verification emails still won't arrive on test right now. That's a separate, infra-side issue in reserve-rec-api: the test Cognito user pool (ca-central-1_sbknhwghf) is missing two settings that were never actually applied when the pool was created (2026-07-14):
  - AutoVerifiedAttributes should include email
  - EmailConfiguration should send via SES using the verified bcparks.ca domain, not Cognito's default sender

####  Why it's still broken after redeploys
  CloudFormation believes these settings are already correctly set, so normal redeploys compute "no diff" and skip re-applying them. Confirmed via detect-stack-drift — not a one-off drift, a deployment-tooling gap.

#### Next steps (tracked separately, not in this PR)
  - Manually patch the live pool via cognito-idp update-user-pool to unblock testing
  - Land a small forcing change in public-identity-stack.js so CloudFormation pushes a real diff on next deploy, keeping it fixed long-term
