### PR TITLE
fix(account): stack the resend-verification button under the message (#633)

### DIFF
--- a/src/app/account-details/account-details.component.html
+++ b/src/app/account-details/account-details.component.html
@@ -5,12 +5,15 @@
 
   <!-- Email not verified -->
   @if (user && !emailVerified) {
-    <div class="alert alert-danger d-flex justify-content-between align-items-center" role="alert">
-      <div>
-        <strong><i class="fa-solid fa-circle-exclamation me-2"></i>You will not be able to book a day-use pass until your email has been verified.</strong>
-        <div class="small mt-1">Please check your inbox for the verification e-mail or select the button to resend.</div>
+    <div class="alert alert-danger verify-alert" role="alert">
+      <i class="fa-solid fa-circle-exclamation verify-alert__icon"></i>
+      <div class="verify-alert__content">
+        <div class="verify-alert__text">
+          <strong class="verify-alert__title">You will not be able to book a day-use pass until your email has been verified.</strong>
+          <p class="verify-alert__body">Please check your inbox for the verification e-mail or select the button below to resend.</p>
+        </div>
+        <button class="btn btn-primary verify-alert__action" (click)="resendVerification()">Resend verification</button>
       </div>
-      <button class="btn btn-primary btn-sm flex-shrink-0 ms-3" (click)="resendVerification()">Resend verification</button>
     </div>
   }
 

--- a/src/app/account-details/account-details.component.scss
+++ b/src/app/account-details/account-details.component.scss
@@ -116,6 +116,68 @@
     color: #d8292f;
   }
 
+  // #633: the unverified-email alert. The design stacks the resend button under
+  // the message at every breakpoint, so the old side-by-side flex row squeezed
+  // the message into a narrow column on a phone. Values come from the three
+  // "Account – Account settings – APRIL" frames (320 / 744 / 1440 wide); only the
+  // button width differs between them.
+  .verify-alert {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 1rem 1.5rem;
+    border: 1px solid #ce3e39;
+    border-radius: 4px;
+    background-color: #f4e1e2;
+    color: #1a1a1a;
+  }
+
+  .verify-alert__icon {
+    flex: 0 0 auto;
+    margin-top: 3px; // drops the 20px icon onto the cap height of the heading
+    color: #ce3e39;
+    font-size: 1.25rem;
+    line-height: 1;
+  }
+
+  .verify-alert__content {
+    flex: 1 1 auto;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+
+  .verify-alert__text {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .verify-alert__title {
+    font-size: 1rem;
+    font-weight: 700;
+    line-height: 1.6;
+  }
+
+  .verify-alert__body {
+    margin-bottom: 0;
+    font-size: 0.8333rem; // 13.33px
+    line-height: 1.6;
+  }
+
+  // Full width everywhere except XL, where the design lets the button hug its label.
+  .verify-alert__action {
+    width: 100%;
+  }
+
+  @media (min-width: 1440px) {
+    .verify-alert__action {
+      width: auto;
+      align-self: flex-start;
+    }
+  }
+
   // #634 item 5: 4px between a field label and its value; muted values at #656565.
   .field-label {
     font-weight: 700;


### PR DESCRIPTION
### Ticket:
Ref #633

### Description:
The unverified-email alert used a single `d-flex justify-content-between` row, so on a phone the button held its width and squeezed the message into a narrow column. The alert is now the icon + stacked-content layout from the ready-for-development frames, with the Figma colours, type scale and 48px button.

The design stacks the button under the message at **all three** breakpoints (320 / 744 / 1440) — the only thing that changes is the button width, which fills below XL and hugs its label at 1440px. So this also changes the desktop rendering, which previously put the button beside the text. Fixing mobile alone would have meant encoding a desktop layout the design doesn't have.

Copy now reads "select the button below to resend", matching the design and the new position.

Verified by rendering the compiled component styles at 390px, 744px and 1440px. 96 unit tests pass, lint clean.