### PR TITLE
fix(account): make Cancel a button and reorder cards on mobile (#634)

### DIFF
--- a/src/app/account-details/account-details.component.html
+++ b/src/app/account-details/account-details.component.html
@@ -31,7 +31,9 @@
   @if (user) {
     <div class="row g-4">
       <!-- Contact information -->
-      <div class="col-lg-8">
+      <!-- Cards stack Contact / Vehicle / Account management on narrow screens
+           (#634 item 4); lg+ keeps the DOM order so the 8+4 row is unchanged. -->
+      <div class="col-lg-8 order-1">
         <div class="card h-100">
           <div class="card-header d-flex justify-content-between align-items-center">
             <span class="fw-semibold">Contact information</span>
@@ -95,7 +97,7 @@
                   <div class="col-md-6"><ngds-text-input label="Alternate phone (optional)" [control]="contactForm.get('secondaryNumber')"></ngds-text-input></div>
                 </div>
                 <div class="d-flex justify-content-end gap-2 mt-3">
-                  <button type="button" class="btn btn-link" [disabled]="saving" (click)="cancelEdit()">Cancel</button>
+                  <button type="button" class="btn btn-outline-primary" [disabled]="saving" (click)="cancelEdit()">Cancel</button>
                   <button type="submit" class="btn btn-primary" [disabled]="saving">Save</button>
                 </div>
               </form>
@@ -104,7 +106,7 @@
         </div>
       </div>
       <!-- Account management -->
-      <div class="col-lg-4">
+      <div class="col-lg-4 order-3 order-lg-2">
         <div class="card h-100">
           <div class="card-header"><span class="fw-semibold">Account management</span></div>
           <div class="card-body">
@@ -133,7 +135,7 @@
           </div>
         </div>
         <!-- Vehicle information -->
-        <div class="col-lg-8">
+        <div class="col-lg-8 order-2 order-lg-3">
           <div class="card">
             <div class="card-header d-flex justify-content-between align-items-center">
               <span class="fw-semibold">Vehicle information <span class="text-muted fw-normal">(optional)</span></span>
@@ -168,7 +170,7 @@
                     </div>
                   </div>
                   <div class="d-flex justify-content-end gap-2 mt-3">
-                    <button type="button" class="btn btn-link" [disabled]="saving" (click)="cancelEdit()">Cancel</button>
+                    <button type="button" class="btn btn-outline-primary" [disabled]="saving" (click)="cancelEdit()">Cancel</button>
                     <button type="submit" class="btn btn-primary" [disabled]="saving">Save</button>
                   </div>
                 </form>

--- a/src/app/account-details/account-details.component.spec.ts
+++ b/src/app/account-details/account-details.component.spec.ts
@@ -179,4 +179,46 @@ describe('AccountDetailsComponent', () => {
     expect(el.querySelectorAll('form').length).toBe(0);
     expect(el.textContent).toContain('Phone numbers');
   });
+
+  // #634 item 3: Cancel is a button in the design, not a text link.
+  ['contact', 'vehicle'].forEach(section => {
+    it(`renders Cancel as a button rather than a link in the ${section} form`, () => {
+      component.startEdit(section as any);
+      fixture.detectChanges();
+
+      const cancel = Array.from(fixture.nativeElement.querySelectorAll('form button'))
+        .find((b: any) => (b.textContent ?? '').trim() === 'Cancel') as HTMLButtonElement;
+
+      expect(cancel).toBeTruthy();
+      expect(cancel.classList).not.toContain('btn-link');
+      expect(cancel.classList).toContain('btn-outline-primary');
+    });
+  });
+
+  // #634 item 4: on narrow screens the cards read Contact, Vehicle, Account
+  // management. lg+ keeps the original 8 + 4 row followed by Vehicle.
+  it('stacks the cards in the designed order on mobile without changing the lg layout', () => {
+    const columns = Array.from(
+      fixture.nativeElement.querySelectorAll('.row > div[class*="col-lg"]')
+    ) as HTMLElement[];
+
+    const labelled = columns.map(col => ({
+      // The Vehicle header carries a nested "(optional)" span; drop it so the
+      // assertion reads as the card names themselves.
+      title: col.querySelector('.card-header span')!.textContent!.replace(/\s*\(optional\)\s*$/, '').trim(),
+      classes: col.className,
+    }));
+
+    const mobile = (c: string) => Number(/(?:^|\s)order-(\d)(?:\s|$)/.exec(c)![1]);
+    const desktop = (c: string) => {
+      const lg = /order-lg-(\d)/.exec(c);
+      return lg ? Number(lg[1]) : mobile(c);
+    };
+
+    expect([...labelled].sort((a, b) => mobile(a.classes) - mobile(b.classes)).map(c => c.title))
+      .toEqual(['Contact information', 'Vehicle information', 'Account management']);
+
+    expect([...labelled].sort((a, b) => desktop(a.classes) - desktop(b.classes)).map(c => c.title))
+      .toEqual(['Contact information', 'Account management', 'Vehicle information']);
+  });
 });


### PR DESCRIPTION
Ticket: #634

### Description

QA round 2 on the account settings page — items 3 and 4 from @manuji's send-back.

- **Cancel is a link, not a button.** Both Cancel controls used `btn btn-link`; they now use `btn btn-outline-primary`, the secondary style already used by Edit and the Change email/password buttons.
- **Card order on mobile.** Below `lg` the cards stacked Contact → Account management → Vehicle. Added Bootstrap ordering so narrow screens read Contact → Vehicle → Account management, while `lg+` keeps the existing 8 + 4 row followed by Vehicle.

Both are covered in `account-details.component.spec.ts`, and each test was checked to fail when its fix is reverted.

Items 1 (resend button alignment) and 2 (verified/not-verified badge styling) are left out deliberately — both need a design decision, raised on the ticket.

Ref #634