### PR TITLE
fix(my-bookings): sort past/cancelled bookings descending by start date

### DIFF
--- a/src/app/my-bookings/my-bookings.component.ts
+++ b/src/app/my-bookings/my-bookings.component.ts
@@ -140,6 +140,11 @@ export class MyBookingsComponent implements OnInit {
 
       this.loading = false;
     });
+
+    // Active ascending (soonest first); past/cancelled descending (most recent first)
+    this.activeBookings.sort((a, b) => DateTime.fromISO(a.startDate).toMillis() - DateTime.fromISO(b.startDate).toMillis());
+    this.pastBookings.sort((a, b) => DateTime.fromISO(b.startDate).toMillis() - DateTime.fromISO(a.startDate).toMillis());
+    this.cancelledBookings.sort((a, b) => DateTime.fromISO(b.startDate).toMillis() - DateTime.fromISO(a.startDate).toMillis());
   }
 
   // Format date range with time of day info


### PR DESCRIPTION
### Ticket:
https://github.com/bcgov/reserve-rec-public/issues/539

### Description:
Sort was missing for the Past and Cancelled sections on My Bookings. Active bookings looked correct because the API happens to return them in the right order, but Past and Cancelled need the opposite order (most recent first), and nothing was reversing that. Added explicit sorting for all three lists after they're built: Active ascending by start date, Past and Cancelled descending by start date.